### PR TITLE
Modify date and time fields to be clearable

### DIFF
--- a/lib/screens/events/components/general_info.dart
+++ b/lib/screens/events/components/general_info.dart
@@ -89,25 +89,29 @@ class EventInfoFieldState extends ConsumerState<EventInfoField> {
             useHorizontalLayout: widget.useHorizontalLayout,
             children: [
               CommonDateField(
-                  labelText: 'Start Date',
-                  hintText: 'Enter date',
-                  controller: widget.collEventCtr.startDateCtr,
-                  initialDate: _getInitialStartDate(),
-                  lastDate: DateTime.now(),
-                  onTap: () {
-                    setState(
-                      () {
-                        // _getEventID();
-                        CollEventServices(ref: ref).updateCollEvent(
-                          widget.collEventId,
-                          CollEventCompanion(
-                            startDate:
-                                db.Value(widget.collEventCtr.startDateCtr.text),
-                          ),
-                        );
-                      },
-                    );
-                  }),
+                labelText: 'Start Date',
+                hintText: 'Enter date',
+                controller: widget.collEventCtr.startDateCtr,
+                initialDate: _getInitialStartDate(),
+                lastDate: DateTime.now(),
+                onTap: () {
+                  CollEventServices(ref: ref).updateCollEvent(
+                    widget.collEventId,
+                    CollEventCompanion(
+                      startDate:
+                          db.Value(widget.collEventCtr.startDateCtr.text),
+                    ),
+                  );
+                },
+                onClear: () {
+                  CollEventServices(ref: ref).updateCollEvent(
+                    widget.collEventId,
+                    CollEventCompanion(
+                      startDate: db.Value(null),
+                    ),
+                  );
+                }
+              ),
               EndDateField(
                 collEventId: widget.collEventId,
                 collEventCtr: widget.collEventCtr,
@@ -172,6 +176,14 @@ class EndDateField extends ConsumerWidget {
           ),
         );
       },
+      onClear: () {
+        CollEventServices(ref: ref).updateCollEvent(
+          collEventId,
+          CollEventCompanion(
+            startDate: db.Value(null),
+          ),
+        );
+      }      
     );
   }
 }
@@ -319,8 +331,8 @@ class EventTimeField extends ConsumerWidget {
       useHorizontalLayout: useHorizontalLayout,
       children: [
         CommonTimeField(
-          labelText: 'Start time',
-          hintText: 'Enter date',
+          labelText: 'Start Time',
+          hintText: 'Enter time',
           controller: collEventCtr.startTimeCtr,
           initialTime: _getInitialTime(ref),
           onTap: () {
@@ -331,10 +343,18 @@ class EventTimeField extends ConsumerWidget {
               ),
             );
           },
+          onClear: () {
+            CollEventServices(ref: ref).updateCollEvent(
+              collEventId,
+              CollEventCompanion(
+                  startTime: db.Value(null)
+              )
+            );
+          }            
         ),
         CommonTimeField(
-          labelText: 'End time',
-          hintText: 'Enter date',
+          labelText: 'End Time',
+          hintText: 'Enter time',
           controller: collEventCtr.endTimeCtr,
           initialTime: _getInitialTime(ref),
           onTap: () {
@@ -345,6 +365,14 @@ class EventTimeField extends ConsumerWidget {
               ),
             );
           },
+          onClear: () {
+            CollEventServices(ref: ref).updateCollEvent(
+              collEventId,
+              CollEventCompanion(
+                  endTime: db.Value(null)
+              )
+            );
+          }         
         ),
       ],
     );

--- a/lib/screens/narrative/components/top_forms.dart
+++ b/lib/screens/narrative/components/top_forms.dart
@@ -62,6 +62,12 @@ class DateForm extends ConsumerWidget {
           NarrativeCompanion(date: db.Value(narrativeCtr.dateCtr.text)),
         );
       },
+      onClear: () {
+        NarrativeServices(ref: ref).updateNarrative(
+          narrativeId,
+          NarrativeCompanion(date: db.Value(null)),
+        );
+      }
     );
   }
 }

--- a/lib/screens/shared/fields.dart
+++ b/lib/screens/shared/fields.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
-class CommonDateField extends StatelessWidget {
+class CommonDateField extends ConsumerStatefulWidget {
   const CommonDateField({
     super.key,
     required this.controller,
@@ -12,6 +12,7 @@ class CommonDateField extends StatelessWidget {
     required this.initialDate,
     required this.lastDate,
     required this.onTap,
+    required this.onClear,
   });
 
   final TextEditingController controller;
@@ -20,25 +21,39 @@ class CommonDateField extends StatelessWidget {
   final DateTime initialDate;
   final DateTime lastDate;
   final VoidCallback onTap;
+  final VoidCallback onClear;
 
+  @override
+  CommonDateFieldState createState() => CommonDateFieldState();
+}
+
+class CommonDateFieldState extends ConsumerState<CommonDateField> {
   @override
   Widget build(BuildContext context) {
     return TextField(
       decoration: InputDecoration(
-        labelText: labelText,
-        hintText: hintText,
+        labelText: widget.labelText,
+        hintText: widget.hintText,
       ),
-      controller: controller,
+      controller: widget.controller,
       onTap: () async {
         final selectedDate = await showDatePicker(
             context: context,
-            initialDate: initialDate,
+            cancelText: "Clear",
+            initialDate: widget.initialDate,
             firstDate: DateTime(2000),
-            lastDate: lastDate);
+            lastDate: widget.lastDate);
 
-        if (selectedDate != null) {
-          controller.text = DateFormat.yMMMd().format(selectedDate);
-          onTap();
+        // OK pressed
+        if (selectedDate != null && mounted) {
+          widget.controller.text = DateFormat.yMMMd().format(selectedDate);
+          widget.onTap();
+        }
+
+        // Clear pressed (or picker closed) 
+        if (selectedDate == null && mounted) {
+          widget.controller.text = "";
+          widget.onClear();
         }
       },
     );
@@ -53,6 +68,7 @@ class CommonTimeField extends ConsumerStatefulWidget {
     required this.hintText,
     required this.initialTime,
     required this.onTap,
+    required this.onClear,
   });
 
   final TextEditingController controller;
@@ -60,6 +76,7 @@ class CommonTimeField extends ConsumerStatefulWidget {
   final String hintText;
   final TimeOfDay initialTime;
   final VoidCallback onTap;
+  final VoidCallback onClear;
 
   @override
   CommonTimeFieldState createState() => CommonTimeFieldState();
@@ -77,11 +94,20 @@ class CommonTimeFieldState extends ConsumerState<CommonTimeField> {
       onTap: () async {
         final time = await _showTimePicker(
           context: context,
+          cancelText: "Clear",
           initialTime: widget.initialTime,
         );
+
+        // OK pressed
         if (time != null && mounted) {
           widget.controller.text = _formatTimeOfDay(time);
           widget.onTap();
+        }
+
+        // Clear pressed (or picker closed)
+        if (time == null && mounted) {
+          widget.controller.text = "";
+          widget.onClear();
         }
       },
     );
@@ -89,10 +115,12 @@ class CommonTimeFieldState extends ConsumerState<CommonTimeField> {
 
   Future<TimeOfDay?> _showTimePicker({
     required BuildContext context,
+    required String cancelText,
     required TimeOfDay initialTime,
   }) {
     return showTimePicker(
       context: context,
+      cancelText: cancelText,
       initialTime: initialTime,
     );
   }

--- a/lib/screens/specimens/shared/associated_data.dart
+++ b/lib/screens/specimens/shared/associated_data.dart
@@ -330,6 +330,7 @@ class AssociatedDataFormState extends ConsumerState<AssociatedDataForm> {
             initialDate: DateTime.now(),
             lastDate: DateTime.now(),
             onTap: () {},
+            onClear: () {},
           ),
           Visibility(
             visible: widget.ctr.typeCtr == 'Link',

--- a/lib/screens/specimens/shared/capture_records.dart
+++ b/lib/screens/specimens/shared/capture_records.dart
@@ -486,19 +486,28 @@ class CaptureDate extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return CommonDateField(
-        labelText: 'Capture date',
-        hintText: 'Enter date',
-        controller: specimenCtr.captureDateCtr,
-        initialDate: DateTime.now(),
-        lastDate: DateTime.now(),
-        onTap: () {
-          SpecimenServices(ref: ref).updateSpecimen(
-            specimenUuid,
-            SpecimenCompanion(
-              captureDate: db.Value(specimenCtr.captureDateCtr.text),
-            ),
-          );
-        });
+      labelText: 'Capture date',
+      hintText: 'Enter date',
+      controller: specimenCtr.captureDateCtr,
+      initialDate: DateTime.now(),
+      lastDate: DateTime.now(),
+      onTap: () {
+        SpecimenServices(ref: ref).updateSpecimen(
+          specimenUuid,
+          SpecimenCompanion(
+            captureDate: db.Value(specimenCtr.captureDateCtr.text),
+          ),
+        );
+      },
+      onClear: () {
+        SpecimenServices(ref: ref).updateSpecimen(
+          specimenUuid,
+          SpecimenCompanion(
+            captureDate: db.Value(null),
+          ),
+        );
+      },      
+    );
   }
 }
 
@@ -613,6 +622,14 @@ class CaptureTimeState extends ConsumerState<CaptureTime> {
                 ),
               );
             },
+            onClear: () {
+              SpecimenServices(ref: ref).updateSpecimen(
+                widget.specimenUuid,
+                SpecimenCompanion(
+                    captureTime: db.Value(null)
+                )
+              );
+            }              
           );
   }
 }

--- a/lib/screens/specimens/shared/general_records.dart
+++ b/lib/screens/specimens/shared/general_records.dart
@@ -240,9 +240,18 @@ class SpecimenCollectionDateField extends ConsumerWidget {
         SpecimenServices(ref: ref).updateSpecimen(
           specimenUuid,
           SpecimenCompanion(
-              collectionDate: db.Value(
-            specimenCtr.collDateCtr.text,
-          )),
+            collectionDate: db.Value(
+              specimenCtr.collDateCtr.text,
+            )
+          ),
+        );
+      },
+      onClear: () {
+        SpecimenServices(ref: ref).updateSpecimen(
+          specimenUuid,
+          SpecimenCompanion(
+            collectionDate: db.Value(null)
+          ),
         );
       }
     );
@@ -273,6 +282,14 @@ class SpecimenCollectionTimeField extends ConsumerWidget {
               collectionTime: db.Value(
             specimenCtr.collTimeCtr.text,
           )),
+        );
+      },
+      onClear: () {
+        SpecimenServices(ref: ref).updateSpecimen(
+          specimenUuid,
+          SpecimenCompanion(
+              collectionTime: db.Value(null)
+          )
         );
       }
     );
@@ -342,6 +359,14 @@ class PrepDateField extends ConsumerWidget {
           ),
         );
       },
+      onClear: () {
+        SpecimenServices(ref: ref).updateSpecimen(
+          specimenUuid,
+          SpecimenCompanion(
+            prepDate: db.Value(null)
+          ),
+        );
+      }      
     );
   }
 }
@@ -359,18 +384,27 @@ class PrepTimeField extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return CommonTimeField(
-        controller: specimenCtr.prepTimeCtr,
-        labelText: 'Prep. time',
-        hintText: 'Enter time',
-        initialTime: TimeOfDay.now(),
-        onTap: () {
-          SpecimenServices(ref: ref).updateSpecimen(
-            specimenUuid,
-            SpecimenCompanion(
-              prepTime: db.Value(specimenCtr.prepTimeCtr.text),
-            ),
-          );
-        });
+      controller: specimenCtr.prepTimeCtr,
+      labelText: 'Prep. time',
+      hintText: 'Enter time',
+      initialTime: TimeOfDay.now(),
+      onTap: () {
+        SpecimenServices(ref: ref).updateSpecimen(
+          specimenUuid,
+          SpecimenCompanion(
+            prepTime: db.Value(specimenCtr.prepTimeCtr.text),
+          ),
+        );
+      },
+      onClear: () {
+        SpecimenServices(ref: ref).updateSpecimen(
+          specimenUuid,
+          SpecimenCompanion(
+              prepTime: db.Value(null)
+          )
+        );
+      }
+    );
   }
 }
 

--- a/lib/screens/specimens/shared/specimen_parts.dart
+++ b/lib/screens/specimens/shared/specimen_parts.dart
@@ -810,6 +810,7 @@ class AdditionalPartFields extends ConsumerWidget {
           controller: partCtr.timeTakenCtr,
           initialTime: TimeOfDay.now(),
           onTap: () {},
+          onClear: () {},
         ),
         Align(
           alignment: Alignment.centerLeft,
@@ -855,6 +856,7 @@ class AdditionalPartFields extends ConsumerWidget {
             initialDate: DateTime.now(),
             lastDate: DateTime.now(),
             onTap: () {},
+            onClear: () {},
           ),
         ),
         Visibility(


### PR DESCRIPTION
- Modifies `CommonDateField` to be stateful.
- Adds an `onClear` callback to `CommonDateField` and `CommonTimeField`, which is used to trigger the clearing of the date/time on a given field when the date/time picker is closed via the Cancel button or closing the window.
- Replaced the "Cancel" text on date/time pickers with "Clear".
- Updates the following date/time fields to be clearable as described above:
  - Events 
    - Start Date
    - End Date 
    - Start Time
    - End Time
  - Narrative
    - Date
  - Specimen General Record
    - Collection Date
    - Collection Time
    - Prep Date
    - Prep Time
  - Specimen Capture Record
    - Capture Date
    - Capture Time
  - Specimen Parts
    - Date Taken
    - Time Taken
  - Specimen Associated Date
    - Date

https://github.com/user-attachments/assets/ef7a8a14-c166-4965-8949-f06fcfe4f535

This resolves #24. 