### PR TITLE
Add dropdown clear option for avian molt fields

### DIFF
--- a/lib/screens/shared/fields.dart
+++ b/lib/screens/shared/fields.dart
@@ -210,6 +210,27 @@ class CommonDropdownText extends StatelessWidget {
   }
 }
 
+class HintDropdownText extends StatelessWidget {
+  const HintDropdownText({super.key, required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+
+    // attempts to copy the default hint text styling
+    final hintStyle = Theme.of(context).inputDecorationTheme.hintStyle?.copyWith(
+        color: Theme.of(context).inputDecorationTheme.hintStyle?.color?.withOpacity(0.6)
+    );
+
+    return Text(
+      text,
+      style: hintStyle,
+      overflow: TextOverflow.ellipsis,
+    );
+  }
+}
+
 class CommonNumField extends ConsumerWidget {
   const CommonNumField({
     super.key,

--- a/lib/screens/shared/fields.dart
+++ b/lib/screens/shared/fields.dart
@@ -459,3 +459,29 @@ class AutoCompleteText extends StatelessWidget {
     );
   }
 }
+
+class DropDownMenuItems {
+  static DropdownMenuItem<int?> chooseOneListItem = DropdownMenuItem(
+    value: null,
+    child: HintDropdownText(text: 'Choose one')
+  );
+  
+  static List<DropdownMenuItem<int?>> booleanDropDownItems() {
+    return [
+      chooseOneListItem,
+      DropdownMenuItem(
+        value: 1,
+        child: CommonDropdownText(text: 'Yes')
+      ),
+      DropdownMenuItem(
+        value: 0,
+        child: CommonDropdownText(text: 'No')
+      )
+    ];
+  }
+
+  static List<DropdownMenuItem<int?>> addChooseOneToList(List<DropdownMenuItem<int?>> list) {
+    list.insert(0, chooseOneListItem);
+    return list;
+  }
+}

--- a/lib/screens/specimens/avian/measurements.dart
+++ b/lib/screens/specimens/avian/measurements.dart
@@ -195,26 +195,16 @@ class BirdMeasurementFormsState extends ConsumerState<BirdMeasurementForms> {
               labelText: 'Brood patch',
               hintText: 'Choose one',
             ),
-            items: const [
-              DropdownMenuItem(
-                value: 1,
-                child: CommonDropdownText(text: 'Yes'),
-              ),
-              DropdownMenuItem(
-                value: 0,
-                child: CommonDropdownText(text: 'No'),
-              ),
-            ],
+            items: DropDownMenuItems.booleanDropDownItems(),
             onChanged: (int? newValue) {
-              if (newValue != null) {
-                setState(() {
-                  SpecimenServices(ref: ref).updateAvianMeasurement(
-                      widget.specimenUuid,
-                      AvianMeasurementCompanion(
-                        broodPatch: db.Value(newValue),
-                      ));
-                });
-              }
+              setState(() {
+                SpecimenServices(ref: ref).updateAvianMeasurement(
+                  widget.specimenUuid,
+                  AvianMeasurementCompanion(
+                    broodPatch: db.Value(newValue),
+                  )
+                );
+              });
             },
           ),
           DropdownButtonFormField<int?>(
@@ -223,27 +213,17 @@ class BirdMeasurementFormsState extends ConsumerState<BirdMeasurementForms> {
               labelText: 'Bursa present',
               hintText: 'Choose one',
             ),
-            items: const [
-              DropdownMenuItem(
-                value: 1,
-                child: CommonDropdownText(text: 'Yes'),
-              ),
-              DropdownMenuItem(
-                value: 0,
-                child: CommonDropdownText(text: 'No'),
-              ),
-            ],
+            items: DropDownMenuItems.booleanDropDownItems(),
             onChanged: (int? newValue) {
-              if (newValue != null) {
-                setState(() {
-                  _hasBursa = newValue == 1;
-                  SpecimenServices(ref: ref).updateAvianMeasurement(
-                      widget.specimenUuid,
-                      AvianMeasurementCompanion(
-                        hasBursa: db.Value(newValue),
-                      ));
-                });
-              }
+              setState(() {
+                _hasBursa = newValue == 1;
+                SpecimenServices(ref: ref).updateAvianMeasurement(
+                  widget.specimenUuid,
+                  AvianMeasurementCompanion(
+                    hasBursa: db.Value(newValue),
+                  )
+                );
+              });
             },
           ),
         ],
@@ -497,6 +477,13 @@ class FemaleGonadFormState extends ConsumerState<FemaleGonadForm> {
   bool _isLargeOvum = false;
   @override
   Widget build(BuildContext context) {
+
+    final List<DropdownMenuItem<int?>> ovaryApperanceItems = 
+      ovaryAppearanceList.map((e) => DropdownMenuItem<int?>(
+        value: ovaryAppearanceList.indexOf(e),
+        child: CommonDropdownText(text: e),
+      )).toList();
+
     return Visibility(
       visible: widget.sex == SpecimenSex.female,
       child: Column(
@@ -548,32 +535,24 @@ class FemaleGonadFormState extends ConsumerState<FemaleGonadForm> {
           ),
           Padding(
             padding: const EdgeInsets.all(5),
-            child: DropdownButtonFormField<OvaryAppearance>(
-              initialValue: _getOvaryAppearance(),
+            child: DropdownButtonFormField<int?>(
+              initialValue: widget.ctr.ovaryAppearanceCtr,
               decoration: const InputDecoration(
                 labelText: 'Appearance',
-                hintText: 'Choose one',
               ),
-              items: ovaryAppearanceList
-                  .map((e) => DropdownMenuItem(
-                        value: OvaryAppearance
-                            .values[ovaryAppearanceList.indexOf(e)],
-                        child: CommonDropdownText(text: e),
-                      ))
-                  .toList(),
-              onChanged: (OvaryAppearance? newValue) {
-                if (newValue != null) {
-                  setState(() {
-                    _isLargeOvum = newValue == OvaryAppearance.large;
-                    SpecimenServices(ref: ref).updateAvianMeasurement(
-                      widget.specimenUuid,
-                      AvianMeasurementCompanion(
-                        ovaryAppearance: db.Value(newValue.index),
-                      ),
-                    );
-                  });
-                }
-              },
+              items: DropDownMenuItems.addChooseOneToList(ovaryApperanceItems),
+              onChanged: (int? newValue) {
+                setState(() {
+                  print(OvaryAppearance.large.index);
+                  _isLargeOvum = (newValue == OvaryAppearance.large.index);
+                  SpecimenServices(ref: ref).updateAvianMeasurement(
+                    widget.specimenUuid,
+                    AvianMeasurementCompanion(
+                      ovaryAppearance: db.Value(newValue),
+                    ),
+                  );
+                });
+              }
             ),
           ),
           Visibility(
@@ -617,13 +596,6 @@ class FemaleGonadFormState extends ConsumerState<FemaleGonadForm> {
       ),
     );
   }
-
-  OvaryAppearance? _getOvaryAppearance() {
-    if (widget.ctr.ovaryAppearanceCtr != null) {
-      return OvaryAppearance.values[widget.ctr.ovaryAppearanceCtr!];
-    }
-    return null;
-  }
 }
 
 class SkullOssField extends ConsumerWidget {
@@ -638,29 +610,29 @@ class SkullOssField extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+
+    final List<DropdownMenuItem<int?>> skullOssItems = 
+      skullOssificationList.map((e) => DropdownMenuItem<int?>(
+        value: e,
+        child: CommonDropdownText(text: '$e %'),
+      )).toList();
+
     return DropdownButtonFormField(
       initialValue: ctr.skullOssCtr,
       decoration: const InputDecoration(
         labelText: 'Skull ossification (%)',
         hintText: 'Enter percentage',
       ),
-      items: skullOssificationList
-          .map((e) => DropdownMenuItem(
-                value: e,
-                child: CommonDropdownText(text: '$e %'),
-              ))
-          .toList(),
+      items: DropDownMenuItems.addChooseOneToList(skullOssItems),
       onChanged: (int? newValue) {
-        if (newValue != null) {
-          ctr.skullOssCtr = newValue;
-          SpecimenServices(ref: ref).updateAvianMeasurement(
-            specimenUuid,
-            AvianMeasurementCompanion(
-              skullOssification: db.Value(newValue),
-            ),
-          );
-        }
-      },
+        ctr.skullOssCtr = newValue;
+        SpecimenServices(ref: ref).updateAvianMeasurement(
+          specimenUuid,
+          AvianMeasurementCompanion(
+            skullOssification: db.Value(newValue),
+          ),
+        );
+      }
     );
   }
 }
@@ -677,35 +649,28 @@ class FatField extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return DropdownButtonFormField<FatCategory>(
-        initialValue: _getFatCategory(),
-        decoration: const InputDecoration(
-          labelText: 'Fat',
-          hintText: 'Enter amount of fat',
-        ),
-        items: fatCategoryList
-            .map((e) => DropdownMenuItem(
-                  value: FatCategory.values[fatCategoryList.indexOf(e)],
-                  child: CommonDropdownText(text: e),
-                ))
-            .toList(),
-        onChanged: (FatCategory? newValue) {
-          if (newValue != null) {
-            SpecimenServices(ref: ref).updateAvianMeasurement(
-              specimenUuid,
-              AvianMeasurementCompanion(
-                fat: db.Value(newValue.index),
-              ),
-            );
-          }
-        });
-  }
 
-  FatCategory? _getFatCategory() {
-    if (ctr.fatCtr != null) {
-      return FatCategory.values[ctr.fatCtr!];
-    }
-    return null;
+  final List<DropdownMenuItem<int?>> fatCategoryItems = 
+    fatCategoryList.map((e) => DropdownMenuItem<int?>(
+      value: fatCategoryList.indexOf(e),
+      child: CommonDropdownText(text: e),
+    )).toList();
+
+  return DropdownButtonFormField(
+      initialValue: ctr.fatCtr,
+      decoration: const InputDecoration(
+        labelText: 'Fat',
+      ),
+      items: DropDownMenuItems.addChooseOneToList(fatCategoryItems),
+      onChanged: (int? newValue) {
+        SpecimenServices(ref: ref).updateAvianMeasurement(
+          specimenUuid,
+          AvianMeasurementCompanion(
+            fat: db.Value(newValue),
+          ),
+        );  
+      }
+    );
   }
 }
 
@@ -804,6 +769,13 @@ class OviductForm extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+
+    final List<DropdownMenuItem<int?>> oviductAppearanceItems = 
+      oviductAppearanceList.map((e) => DropdownMenuItem<int?>(
+        value: oviductAppearanceList.indexOf(e),
+        child: CommonDropdownText(text: e),
+      )).toList();
+
     return AdaptiveLayout(useHorizontalLayout: useHorizontalLayout, children: [
       CommonNumField(
         controller: ctr.oviductWidthCtr,
@@ -822,38 +794,22 @@ class OviductForm extends ConsumerWidget {
           }
         },
       ),
-      DropdownButtonFormField<OviductAppearance>(
-        initialValue: _getOviductAppearance(),
+      DropdownButtonFormField<int?>(
+        initialValue: ctr.oviductAppearanceCtr,
         decoration: const InputDecoration(
           labelText: 'Appearance',
-          hintText: 'Choose one',
         ),
-        items: oviductAppearanceList
-            .map((e) => DropdownMenuItem(
-                  value: OviductAppearance
-                      .values[oviductAppearanceList.indexOf(e)],
-                  child: CommonDropdownText(text: e),
-                ))
-            .toList(),
-        onChanged: (OviductAppearance? newValue) {
-          if (newValue != null) {
-            SpecimenServices(ref: ref).updateAvianMeasurement(
-              specimenUuid,
-              AvianMeasurementCompanion(
-                oviductAppearance: db.Value(newValue.index),
-              ),
-            );
-          }
-        },
+        items: DropDownMenuItems.addChooseOneToList(oviductAppearanceItems),
+        onChanged: (int? newValue) {
+          SpecimenServices(ref: ref).updateAvianMeasurement(
+            specimenUuid,
+            AvianMeasurementCompanion(
+              oviductAppearance: db.Value(newValue),
+            ),
+          );
+        }
       ),
     ]);
-  }
-
-  OviductAppearance? _getOviductAppearance() {
-    if (ctr.oviductAppearanceCtr != null) {
-      return OviductAppearance.values[ctr.oviductAppearanceCtr!];
-    }
-    return null;
   }
 }
 
@@ -897,23 +853,10 @@ class MoltingFormState extends ConsumerState<MoltingForm> {
             decoration: const InputDecoration(
               labelText: 'Wing Molting',
             ),
-            items: const [
-              DropdownMenuItem(
-                value: null,
-                child: HintDropdownText(text: 'Choose one'),
-              ),
-              DropdownMenuItem(
-                value: 1,
-                child: CommonDropdownText(text: 'Yes'),
-              ),
-              DropdownMenuItem(
-                value: 0,
-                child: CommonDropdownText(text: 'No'),
-              ),
-            ],
+            items: DropDownMenuItems.booleanDropDownItems(),
             onChanged: (int? newValue) {
               setState(() {
-                _wingMolting = (newValue != null && newValue == 1) ? true : false;
+                _wingMolting = newValue == 1;
                 SpecimenServices(ref: ref).updateAvianMeasurement(
                     widget.specimenUuid,
                     AvianMeasurementCompanion(
@@ -935,23 +878,10 @@ class MoltingFormState extends ConsumerState<MoltingForm> {
             decoration: const InputDecoration(
               labelText: 'Tail Molting'
             ),
-            items: const [
-              DropdownMenuItem(
-                value: null,
-                child: HintDropdownText(text: 'Choose one'),
-              ),              
-              DropdownMenuItem(
-                value: 1,
-                child: CommonDropdownText(text: 'Yes'),
-              ),
-              DropdownMenuItem(
-                value: 0,
-                child: CommonDropdownText(text: 'No'),
-              ),
-            ],
+            items: DropDownMenuItems.booleanDropDownItems(),
             onChanged: (int? newValue) {
               setState(() {
-                _tailMolting = (newValue != null && newValue == 1) ? true : false;
+                _tailMolting = newValue == 1;
                 SpecimenServices(ref: ref).updateAvianMeasurement(
                     widget.specimenUuid,
                     AvianMeasurementCompanion(
@@ -1071,28 +1001,27 @@ class BodyMoltForm extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return DropdownButtonFormField<BodyMolt>(
-      initialValue: _getMoltValue(),
+
+    final List<DropdownMenuItem<int?>> bodyMoltItems = 
+      bodyMoltList.map((e) => DropdownMenuItem<int?>(
+        value: bodyMoltList.indexOf(e),
+        child: CommonDropdownText(text: e),
+      )).toList();
+
+    return DropdownButtonFormField<int?>(
+      initialValue: ctr.bodyMoltCtr,
       decoration: const InputDecoration(
         labelText: 'Body Molt',
-        hintText: 'Choose one',
       ),
-      items: bodyMoltList
-          .map((e) => DropdownMenuItem(
-                value: BodyMolt.values[bodyMoltList.indexOf(e)],
-                child: CommonDropdownText(text: e),
-              ))
-          .toList(),
-      onChanged: (BodyMolt? newValue) {
-        if (newValue != null) {
-          SpecimenServices(ref: ref).updateAvianMeasurement(
-            specimenUuid,
-            AvianMeasurementCompanion(
-              bodyMolt: db.Value(newValue.index),
-            ),
-          );
-        }
-      },
+      items: DropDownMenuItems.addChooseOneToList(bodyMoltItems),
+      onChanged: (int? newValue) {
+        SpecimenServices(ref: ref).updateAvianMeasurement(
+          specimenUuid,
+          AvianMeasurementCompanion(
+            bodyMolt: db.Value(newValue),
+          ),
+        );
+      }
     );
   }
 

--- a/lib/screens/specimens/avian/measurements.dart
+++ b/lib/screens/specimens/avian/measurements.dart
@@ -896,9 +896,12 @@ class MoltingFormState extends ConsumerState<MoltingForm> {
             initialValue: widget.ctr.wingIsMoltCtr,
             decoration: const InputDecoration(
               labelText: 'Wing Molting',
-              hintText: 'Choose one',
             ),
             items: const [
+              DropdownMenuItem(
+                value: null,
+                child: HintDropdownText(text: 'Choose one'),
+              ),
               DropdownMenuItem(
                 value: 1,
                 child: CommonDropdownText(text: 'Yes'),
@@ -909,16 +912,14 @@ class MoltingFormState extends ConsumerState<MoltingForm> {
               ),
             ],
             onChanged: (int? newValue) {
-              if (newValue != null) {
-                setState(() {
-                  _wingMolting = newValue == 1 ? true : false;
-                  SpecimenServices(ref: ref).updateAvianMeasurement(
-                      widget.specimenUuid,
-                      AvianMeasurementCompanion(
-                        wingIsMolt: db.Value(newValue),
-                      ));
-                });
-              }
+              setState(() {
+                _wingMolting = (newValue != null && newValue == 1) ? true : false;
+                SpecimenServices(ref: ref).updateAvianMeasurement(
+                    widget.specimenUuid,
+                    AvianMeasurementCompanion(
+                      wingIsMolt: db.Value(newValue),
+                    ));
+              });
             },
           ),
           Visibility(
@@ -932,10 +933,13 @@ class MoltingFormState extends ConsumerState<MoltingForm> {
           DropdownButtonFormField<int?>(
             initialValue: widget.ctr.wingIsMoltCtr,
             decoration: const InputDecoration(
-              labelText: 'Tail Molting',
-              hintText: 'Choose one',
+              labelText: 'Tail Molting'
             ),
             items: const [
+              DropdownMenuItem(
+                value: null,
+                child: HintDropdownText(text: 'Choose one'),
+              ),              
               DropdownMenuItem(
                 value: 1,
                 child: CommonDropdownText(text: 'Yes'),
@@ -946,16 +950,14 @@ class MoltingFormState extends ConsumerState<MoltingForm> {
               ),
             ],
             onChanged: (int? newValue) {
-              if (newValue != null) {
-                setState(() {
-                  _tailMolting = newValue == 1 ? true : false;
-                  SpecimenServices(ref: ref).updateAvianMeasurement(
-                      widget.specimenUuid,
-                      AvianMeasurementCompanion(
-                        tailIsMolt: db.Value(newValue),
-                      ));
-                });
-              }
+              setState(() {
+                _tailMolting = (newValue != null && newValue == 1) ? true : false;
+                SpecimenServices(ref: ref).updateAvianMeasurement(
+                    widget.specimenUuid,
+                    AvianMeasurementCompanion(
+                      tailIsMolt: db.Value(newValue),
+                    ));
+              });
             },
           ),
           Visibility(

--- a/lib/styles/themes.dart
+++ b/lib/styles/themes.dart
@@ -64,6 +64,12 @@ class NahpuTheme {
       floatingLabelStyle: TextStyle(
         fontSize: 16,
       ),
+      hintStyle: TextStyle(
+        fontSize: 16,
+        color: const Color(0xfffafafa),
+        fontWeight: FontWeight.w600,
+        letterSpacing: 0.11
+      ),
     );
   }
 }


### PR DESCRIPTION
- Adds a `hintStyle` theme that attempts to mimic the default hint style present on dropdown fields (bold, light grey, small spacing)
- Adds the `HintDropdownText` widget that applies the style above to be used as the "null" option in certain dropdowns.
- Adds a `DropdownMenuItems` helper class that provides a standard "Choose one"/"Yes"/"No" list of menu items and a method to append a "Choose one" option to other lists.
- Adds a 'Choose one' `DropdownMenuItem` to the fields notes below. Selecting this effectively clears and resets the field.
  - Body Molt
  - Wing Molt 
  - Tail Molt
  - Brood patch
  - Bursa present
  - Skull ossification (%)
  - Fat
  - Ovary size appearance
  - Oviduct apperance


<img width="1266" height="713" alt="image" src="https://github.com/user-attachments/assets/f2af0eff-b1f5-4312-b611-e2364addbae9" />

This resolves #26 and #29.