### PR TITLE
Add alert dialog to DB match operations

### DIFF
--- a/lib/screens/settings/collevent_settings.dart
+++ b/lib/screens/settings/collevent_settings.dart
@@ -65,7 +65,17 @@ class CollMethodSettings extends ConsumerWidget {
       },
       resetLabel: 'Match database methods',
       onReset: () {
-        CollMethodServices(ref: ref).getAllMethods();
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return CommonAlertDialog(
+              titleText: 'Match database methods?',
+              descText: 'Matching database types will'
+                ' delete all unused collection methods',
+              confirmFunction: CollMethodServices(ref: ref).getAllMethods,
+            );
+          },
+        );
       },
     );
   }
@@ -103,7 +113,17 @@ class PersonnelRoleSetting extends ConsumerWidget {
       },
       resetLabel: 'Match database roles',
       onReset: () {
-        CollEvenPersonnelServices(ref: ref).getAllRoles();
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return CommonAlertDialog(
+              titleText: 'Match database roles?',
+              descText: 'Matching database types will'
+                ' delete all unused personnel roles',
+              confirmFunction: CollEvenPersonnelServices(ref: ref).getAllRoles,
+            );
+          },
+        );
       },
     );
   }

--- a/lib/screens/settings/specimen_settings.dart
+++ b/lib/screens/settings/specimen_settings.dart
@@ -112,7 +112,19 @@ class SpecimenTypeSettings extends ConsumerWidget {
         }
       },
       resetLabel: 'Match database types',
-      onReset: () => SpecimenPartServices(ref: ref).getSpecimenTypes(),
+      onReset: () {
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return CommonAlertDialog(
+              titleText: 'Match database types?',
+              descText: 'Matching database types will'
+                ' delete all unused specimen part types',
+              confirmFunction: SpecimenPartServices(ref: ref).getSpecimenTypes,
+            );
+          },
+        );
+      },
     );
   }
 }
@@ -156,7 +168,19 @@ class TreatmentOptionSettings extends ConsumerWidget {
         }
       },
       resetLabel: 'Match database treatments',
-      onReset: () => SpecimenPartServices(ref: ref).getTreatmentOptions(),
+      onReset: () {
+        showDialog(
+          context: context,
+          builder: (BuildContext context) {
+            return CommonAlertDialog(
+              titleText: 'Match database treatments?',
+              descText: 'Matching database types will'
+                ' delete all unused treatments',
+              confirmFunction: SpecimenPartServices(ref: ref).getTreatmentOptions,
+            );
+          }
+        );
+      }
     );
   }
 }

--- a/lib/screens/shared/common.dart
+++ b/lib/screens/shared/common.dart
@@ -71,6 +71,47 @@ class CommonLineDivider extends StatelessWidget {
   }
 }
 
+class CommonAlertDialog extends StatelessWidget {
+  const CommonAlertDialog({
+    super.key,
+    required this.titleText,
+    this.descText,
+    required this.confirmFunction
+  });
+
+  final String titleText;
+  final String? descText;
+  final Function() confirmFunction;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(titleText),
+      content: descText == null ? null: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 350),
+        child:
+          Text(descText!)),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.pop(context);
+          }, 
+          child: const Text('Cancel')
+        ),
+        TextButton(
+          onPressed: () {
+            confirmFunction();
+            if (context.mounted) {
+              Navigator.pop(context);
+            }
+          }, 
+          child: const Text('OK')
+        )
+      ],
+    );
+  }
+}
+
 class TileSvgIcon extends StatelessWidget {
   const TileSvgIcon({super.key, required this.iconPath});
 


### PR DESCRIPTION
- Adds a common alert dialog widget with customizable title, text, and confirm callback function
- Adds confirmation alert dialog to the following match DB operations in project settings:
  - Collection methods
  - Personnel roles
  - Specimen part types
  - Treatments


https://github.com/user-attachments/assets/90584548-5add-4a23-873b-1ea545a87190



This closes #33 