### PR TITLE
Configurable text case for custom fields

### DIFF
--- a/lib/screens/settings/collevent_settings.dart
+++ b/lib/screens/settings/collevent_settings.dart
@@ -77,6 +77,7 @@ class CollMethodSettings extends ConsumerWidget {
           },
         );
       },
+      forceSentenceCase: true,
     );
   }
 }
@@ -125,6 +126,7 @@ class PersonnelRoleSetting extends ConsumerWidget {
           },
         );
       },
+      forceSentenceCase: true,
     );
   }
 }

--- a/lib/screens/settings/collevent_settings.dart
+++ b/lib/screens/settings/collevent_settings.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/services/providers/collevents.dart';
 import 'package:nahpu/screens/settings/common.dart';
 import 'package:nahpu/screens/shared/common.dart';
+import 'package:nahpu/screens/shared/layout.dart';
 import 'package:nahpu/services/collevent_services.dart';
 
 class CollEventSelection extends StatefulWidget {
@@ -16,18 +17,49 @@ class _CollEventSelectionState extends State<CollEventSelection> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Collection Event Settings'),
-      ),
-      body: const SafeArea(
-        child: CommonSettingList(
-          sections: [
-            CollMethodSettings(),
-            PersonnelRoleSetting(),
-          ],
+        appBar: AppBar(
+          title: const Text('Collection Event Settings'),
         ),
-      ),
-    );
+        body: SafeArea(child: LayoutBuilder(
+            builder: (BuildContext context, BoxConstraints constraints) {
+          bool isMobile = constraints.maxWidth < 600;
+          return CommonSettingList(
+            sections: [
+              SpecimenFormats(
+                isMobile: isMobile,
+              ),
+              CollMethodSettings(),
+              PersonnelRoleSetting(),
+            ],
+          );
+        })));
+  }
+}
+
+class SpecimenFormats extends ConsumerWidget {
+  const SpecimenFormats({super.key, required this.isMobile});
+
+  final bool isMobile;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CommonSettingSection(title: 'Formats', children: [
+      Padding(
+          padding: const EdgeInsets.all(16),
+          child: AdaptiveLayout(
+            useHorizontalLayout: !isMobile,
+            children: [
+              TextCaseFmtDropDown(
+                  ref: ref,
+                  label: 'Collection methods',
+                  textCasePrefString: collEventMethodFmtPrefKey),
+              TextCaseFmtDropDown(
+                  ref: ref,
+                  label: 'Personnel roles',
+                  textCasePrefString: collPersonnelRoleFmtPrefKey),
+            ],
+          ))
+    ]);
   }
 }
 
@@ -40,6 +72,8 @@ class CollMethodSettings extends ConsumerWidget {
     return SettingChips(
       title: 'Collection methods',
       controller: controller,
+      ref: ref,
+      textCasePrefString: collEventMethodFmtPrefKey,
       chipList: ref.watch(collEventMethodProvider).when(
             data: (data) {
               return data.map((e) {
@@ -71,13 +105,12 @@ class CollMethodSettings extends ConsumerWidget {
             return CommonAlertDialog(
               titleText: 'Match database methods?',
               descText: 'Matching database types will'
-                ' delete all unused collection methods',
+                  ' delete all unused collection methods',
               confirmFunction: CollMethodServices(ref: ref).getAllMethods,
             );
           },
         );
       },
-      forceSentenceCase: true,
     );
   }
 }
@@ -91,6 +124,8 @@ class PersonnelRoleSetting extends ConsumerWidget {
     return SettingChips(
       title: 'Personnel roles',
       controller: controller,
+      ref: ref,
+      textCasePrefString: collPersonnelRoleFmtPrefKey,
       chipList: ref.watch(collPersonnelRoleProvider).when(
             data: (data) {
               return data.map((e) {
@@ -120,13 +155,12 @@ class PersonnelRoleSetting extends ConsumerWidget {
             return CommonAlertDialog(
               titleText: 'Match database roles?',
               descText: 'Matching database types will'
-                ' delete all unused personnel roles',
+                  ' delete all unused personnel roles',
               confirmFunction: CollEvenPersonnelServices(ref: ref).getAllRoles,
             );
           },
         );
       },
-      forceSentenceCase: true,
     );
   }
 }

--- a/lib/screens/settings/collevent_settings.dart
+++ b/lib/screens/settings/collevent_settings.dart
@@ -25,7 +25,7 @@ class _CollEventSelectionState extends State<CollEventSelection> {
           bool isMobile = constraints.maxWidth < 600;
           return CommonSettingList(
             sections: [
-              SpecimenFormats(
+              EventFormats(
                 isMobile: isMobile,
               ),
               CollMethodSettings(),
@@ -36,8 +36,8 @@ class _CollEventSelectionState extends State<CollEventSelection> {
   }
 }
 
-class SpecimenFormats extends ConsumerWidget {
-  const SpecimenFormats({super.key, required this.isMobile});
+class EventFormats extends ConsumerWidget {
+  const EventFormats({super.key, required this.isMobile});
 
   final bool isMobile;
 

--- a/lib/screens/settings/common.dart
+++ b/lib/screens/settings/common.dart
@@ -210,6 +210,7 @@ class SettingChips extends StatelessWidget {
     required this.onPressed,
     required this.resetLabel,
     required this.onReset,
+    required this.forceSentenceCase,
   });
 
   final String title;
@@ -220,6 +221,7 @@ class SettingChips extends StatelessWidget {
   final TextEditingController controller;
   final String resetLabel;
   final VoidCallback onReset;
+  final bool forceSentenceCase;
 
   @override
   Widget build(BuildContext context) {
@@ -251,7 +253,7 @@ class SettingChips extends StatelessWidget {
                 onChanged: (String value) {
                   if (value.isNotEmpty) {
                     controller.value = TextEditingValue(
-                      text: value.toSentenceCase(),
+                      text: forceSentenceCase ? value.toSentenceCase() : value,
                       selection: controller.selection,
                     );
                   }

--- a/lib/screens/settings/common.dart
+++ b/lib/screens/settings/common.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nahpu/services/providers/settings.dart';
 import 'package:nahpu/services/utility_services.dart';
+import 'package:nahpu/screens/shared/common.dart';
+import 'package:nahpu/screens/shared/fields.dart';
 
 class CommonSettingList extends StatelessWidget {
   const CommonSettingList({
@@ -204,24 +208,26 @@ class SettingChips extends StatelessWidget {
     super.key,
     required this.title,
     required this.controller,
+    required this.ref,
+    required this.textCasePrefString,
     required this.labelText,
     required this.chipList,
     required this.hintText,
     required this.onPressed,
     required this.resetLabel,
     required this.onReset,
-    required this.forceSentenceCase,
   });
 
   final String title;
-  final String labelText;
-  final String hintText;
-  final List<Widget> chipList;
-  final VoidCallback onPressed;
   final TextEditingController controller;
+  final WidgetRef ref;
+  final String textCasePrefString;
+  final String labelText;
+  final List<Widget> chipList;
+  final String hintText;
+  final VoidCallback onPressed;
   final String resetLabel;
   final VoidCallback onReset;
-  final bool forceSentenceCase;
 
   @override
   Widget build(BuildContext context) {
@@ -243,28 +249,15 @@ class SettingChips extends StatelessWidget {
           crossAxisAlignment: CrossAxisAlignment.end,
           children: [
             ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 270),
-              child: TextField(
-                controller: controller,
-                decoration: InputDecoration(
+                constraints: const BoxConstraints(maxWidth: 270),
+                child: AsyncTextField(
+                  controller: controller,
                   labelText: labelText,
                   hintText: hintText,
-                ),
-                onChanged: (String value) {
-                  if (value.isNotEmpty) {
-                    controller.value = TextEditingValue(
-                      text: forceSentenceCase ? value.toSentenceCase() : value,
-                      selection: controller.selection,
-                    );
-                  }
-                },
-                onSubmitted: (String? value) {
-                  if (value != null && value.isNotEmpty) {
-                    onPressed();
-                  }
-                },
-              ),
-            ),
+                  onPressed: onPressed,
+                  ref: ref,
+                  textCasePrefString: textCasePrefString,
+                )),
             IconButton(
               iconSize: 25,
               color: Theme.of(context).colorScheme.onSurface,
@@ -287,6 +280,91 @@ class SettingChips extends StatelessWidget {
         )
       ],
     );
+  }
+}
+
+class AsyncTextField extends StatelessWidget {
+  const AsyncTextField({
+    super.key,
+    required this.controller,
+    required this.labelText,
+    required this.hintText,
+    required this.onPressed,
+    required this.ref,
+    required this.textCasePrefString,
+  });
+
+  final TextEditingController controller;
+  final String labelText;
+  final String hintText;
+  final VoidCallback onPressed;
+  final WidgetRef ref;
+  final String textCasePrefString;
+
+  @override
+  Widget build(BuildContext context) {
+    return ref.watch(textCaseFmtNotifierProvider(textCasePrefString)).when(
+          data: (fmt) => TextField(
+            controller: controller,
+            decoration: InputDecoration(
+              labelText: labelText,
+              hintText: hintText,
+            ),
+            onChanged: (String value) {
+              if (value.isNotEmpty) {
+                controller.value = TextEditingValue(
+                  text: value.toTextCaseFmt(fmt),
+                  selection: controller.selection,
+                );
+              }
+            },
+            onSubmitted: (String? value) {
+              if (value != null && value.isNotEmpty) {
+                onPressed();
+              }
+            },
+          ),
+          loading: () => CommonProgressIndicator(),
+          error: (e, s) => Text('Error'),
+        );
+  }
+}
+
+class TextCaseFmtDropDown extends StatelessWidget {
+  const TextCaseFmtDropDown({
+    super.key,
+    required this.ref,
+    required this.label,
+    required this.textCasePrefString,
+  });
+
+  final WidgetRef ref;
+  final String label;
+  final String textCasePrefString;
+
+  @override
+  Widget build(BuildContext context) {
+    return ref.watch(textCaseFmtNotifierProvider(textCasePrefString)).when(
+          data: (fmt) => DropdownButtonFormField<TextCaseFmt>(
+              initialValue: fmt,
+              decoration: InputDecoration(
+                labelText: label,
+              ),
+              items: textCaseFmtMap.entries
+                  .map((e) => DropdownMenuItem<TextCaseFmt>(
+                      value: e.key, child: CommonDropdownText(text: e.value)))
+                  .toList(),
+              onChanged: (TextCaseFmt? selectedFmt) {
+                if (selectedFmt != null) {
+                  ref
+                      .read(textCaseFmtNotifierProvider(textCasePrefString)
+                          .notifier)
+                      .set(textCasePrefString, selectedFmt);
+                }
+              }),
+          loading: () => const CommonProgressIndicator(),
+          error: (e, s) => const Text('Error'),
+        );
   }
 }
 

--- a/lib/screens/settings/specimen_settings.dart
+++ b/lib/screens/settings/specimen_settings.dart
@@ -125,6 +125,7 @@ class SpecimenTypeSettings extends ConsumerWidget {
           },
         );
       },
+      forceSentenceCase: true,
     );
   }
 }
@@ -180,7 +181,8 @@ class TreatmentOptionSettings extends ConsumerWidget {
             );
           }
         );
-      }
+      },
+      forceSentenceCase: false,
     );
   }
 }

--- a/lib/screens/settings/specimen_settings.dart
+++ b/lib/screens/settings/specimen_settings.dart
@@ -63,6 +63,9 @@ class SpecimenSelectionState extends ConsumerState<SpecimenSelection> {
               TissueIDFields(
                 isMobile: isMobile,
               ),
+              SpecimenFormats(
+                isMobile: isMobile,
+              ),
               const SpecimenTypeSettings(),
               const TreatmentOptionSettings(),
             ],
@@ -70,6 +73,33 @@ class SpecimenSelectionState extends ConsumerState<SpecimenSelection> {
         },
       )),
     );
+  }
+}
+
+class SpecimenFormats extends ConsumerWidget {
+  const SpecimenFormats({super.key, required this.isMobile});
+
+  final bool isMobile;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CommonSettingSection(title: 'Formats', children: [
+      Padding(
+          padding: const EdgeInsets.all(16),
+          child: AdaptiveLayout(
+            useHorizontalLayout: !isMobile,
+            children: [
+              TextCaseFmtDropDown(
+                  ref: ref,
+                  label: 'Specimen part types',
+                  textCasePrefString: specimenTypeFmtPrefKey),
+              TextCaseFmtDropDown(
+                  ref: ref,
+                  label: 'Treatment types',
+                  textCasePrefString: treatmentFmtPrefKey),
+            ],
+          ))
+    ]);
   }
 }
 
@@ -84,6 +114,8 @@ class SpecimenTypeSettings extends ConsumerWidget {
     return SettingChips(
       title: 'Specimen part types',
       controller: partController,
+      ref: ref,
+      textCasePrefString: specimenTypeFmtPrefKey,
       chipList: ref.watch(specimenTypesProvider).when(
             data: (data) {
               return data
@@ -119,13 +151,12 @@ class SpecimenTypeSettings extends ConsumerWidget {
             return CommonAlertDialog(
               titleText: 'Match database types?',
               descText: 'Matching database types will'
-                ' delete all unused specimen part types',
+                  ' delete all unused specimen part types',
               confirmFunction: SpecimenPartServices(ref: ref).getSpecimenTypes,
             );
           },
         );
       },
-      forceSentenceCase: true,
     );
   }
 }
@@ -141,6 +172,8 @@ class TreatmentOptionSettings extends ConsumerWidget {
     return SettingChips(
       title: 'Treatments',
       controller: treatmentController,
+      ref: ref,
+      textCasePrefString: treatmentFmtPrefKey,
       chipList: ref.watch(treatmentOptionsProvider).when(
             data: (data) {
               return data
@@ -171,18 +204,17 @@ class TreatmentOptionSettings extends ConsumerWidget {
       resetLabel: 'Match database treatments',
       onReset: () {
         showDialog(
-          context: context,
-          builder: (BuildContext context) {
-            return CommonAlertDialog(
-              titleText: 'Match database treatments?',
-              descText: 'Matching database types will'
-                ' delete all unused treatments',
-              confirmFunction: SpecimenPartServices(ref: ref).getTreatmentOptions,
-            );
-          }
-        );
+            context: context,
+            builder: (BuildContext context) {
+              return CommonAlertDialog(
+                titleText: 'Match database treatments?',
+                descText: 'Matching database types will'
+                    ' delete all unused treatments',
+                confirmFunction:
+                    SpecimenPartServices(ref: ref).getTreatmentOptions,
+              );
+            });
       },
-      forceSentenceCase: false,
     );
   }
 }

--- a/lib/services/providers/collevents.dart
+++ b/lib/services/providers/collevents.dart
@@ -13,7 +13,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'collevents.g.dart';
 
 const String collEventMethodPrefKey = 'collEventMethods';
+const String collEventMethodFmtPrefKey = 'collEventMethodFmt';
 const String collPersonnelRolePrefKey = 'collPersonnelRoles';
+const String collPersonnelRoleFmtPrefKey = 'collPersonnelRoleFmt';
 
 @riverpod
 class CollEventEntry extends _$CollEventEntry {

--- a/lib/services/providers/settings.dart
+++ b/lib/services/providers/settings.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
+import 'package:nahpu/services/utility_services.dart';
 
 part 'settings.g.dart';
 
@@ -64,5 +65,42 @@ class ThemeSetting extends _$ThemeSetting {
       case ThemeMode.system:
         return 'system';
     }
+  }
+}
+
+@riverpod
+class TextCaseFmtNotifier extends _$TextCaseFmtNotifier {
+  Future<TextCaseFmt> _fetchSettings(String prefKey) async {
+    final prefs = ref.watch(settingProvider);
+    final fmtString = prefs.getString(prefKey);
+
+    TextCaseFmt fmt =
+        TextCaseFmt.values.byName(fmtString ?? TextCaseFmt.anyCase.name);
+
+    if (fmtString == null) {
+      await prefs.setString(prefKey, fmt.name);
+    }
+
+    return fmt;
+  }
+
+  @override
+  FutureOr<TextCaseFmt> build(String prefKey) async {
+    return await _fetchSettings(prefKey);
+  }
+
+  Future<void> set(String prefKey, TextCaseFmt fmt) async {
+    state = const AsyncValue.loading();
+    state = await AsyncValue.guard(() async {
+      final prefs = ref.watch(settingProvider);
+      final fmtString = prefs.getString(prefKey);
+      final setFmt =
+          TextCaseFmt.values.byName(fmtString ?? TextCaseFmt.anyCase.name);
+
+      if (setFmt == fmt) return fmt;
+
+      await prefs.setString(prefKey, fmt.name);
+      return fmt;
+    });
   }
 }

--- a/lib/services/providers/settings.g.dart
+++ b/lib/services/providers/settings.g.dart
@@ -37,5 +37,173 @@ final themeSettingProvider =
 );
 
 typedef _$ThemeSetting = AsyncNotifier<ThemeMode>;
+String _$textCaseFmtNotifierHash() =>
+    r'81bb739ee4cbc4ddbbf686b24778fbe0ee24562e';
+
+/// Copied from Dart SDK
+class _SystemHash {
+  _SystemHash._();
+
+  static int combine(int hash, int value) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + value);
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
+    return hash ^ (hash >> 6);
+  }
+
+  static int finish(int hash) {
+    // ignore: parameter_assignments
+    hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
+    // ignore: parameter_assignments
+    hash = hash ^ (hash >> 11);
+    return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
+  }
+}
+
+abstract class _$TextCaseFmtNotifier
+    extends BuildlessAutoDisposeAsyncNotifier<TextCaseFmt> {
+  late final String prefKey;
+
+  FutureOr<TextCaseFmt> build(
+    String prefKey,
+  );
+}
+
+/// See also [TextCaseFmtNotifier].
+@ProviderFor(TextCaseFmtNotifier)
+const textCaseFmtNotifierProvider = TextCaseFmtNotifierFamily();
+
+/// See also [TextCaseFmtNotifier].
+class TextCaseFmtNotifierFamily extends Family<AsyncValue<TextCaseFmt>> {
+  /// See also [TextCaseFmtNotifier].
+  const TextCaseFmtNotifierFamily();
+
+  /// See also [TextCaseFmtNotifier].
+  TextCaseFmtNotifierProvider call(
+    String prefKey,
+  ) {
+    return TextCaseFmtNotifierProvider(
+      prefKey,
+    );
+  }
+
+  @override
+  TextCaseFmtNotifierProvider getProviderOverride(
+    covariant TextCaseFmtNotifierProvider provider,
+  ) {
+    return call(
+      provider.prefKey,
+    );
+  }
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'textCaseFmtNotifierProvider';
+}
+
+/// See also [TextCaseFmtNotifier].
+class TextCaseFmtNotifierProvider extends AutoDisposeAsyncNotifierProviderImpl<
+    TextCaseFmtNotifier, TextCaseFmt> {
+  /// See also [TextCaseFmtNotifier].
+  TextCaseFmtNotifierProvider(
+    String prefKey,
+  ) : this._internal(
+          () => TextCaseFmtNotifier()..prefKey = prefKey,
+          from: textCaseFmtNotifierProvider,
+          name: r'textCaseFmtNotifierProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$textCaseFmtNotifierHash,
+          dependencies: TextCaseFmtNotifierFamily._dependencies,
+          allTransitiveDependencies:
+              TextCaseFmtNotifierFamily._allTransitiveDependencies,
+          prefKey: prefKey,
+        );
+
+  TextCaseFmtNotifierProvider._internal(
+    super._createNotifier, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.prefKey,
+  }) : super.internal();
+
+  final String prefKey;
+
+  @override
+  FutureOr<TextCaseFmt> runNotifierBuild(
+    covariant TextCaseFmtNotifier notifier,
+  ) {
+    return notifier.build(
+      prefKey,
+    );
+  }
+
+  @override
+  Override overrideWith(TextCaseFmtNotifier Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: TextCaseFmtNotifierProvider._internal(
+        () => create()..prefKey = prefKey,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        prefKey: prefKey,
+      ),
+    );
+  }
+
+  @override
+  AutoDisposeAsyncNotifierProviderElement<TextCaseFmtNotifier, TextCaseFmt>
+      createElement() {
+    return _TextCaseFmtNotifierProviderElement(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is TextCaseFmtNotifierProvider && other.prefKey == prefKey;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, prefKey.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+@Deprecated('Will be removed in 3.0. Use Ref instead')
+// ignore: unused_element
+mixin TextCaseFmtNotifierRef
+    on AutoDisposeAsyncNotifierProviderRef<TextCaseFmt> {
+  /// The parameter `prefKey` of this provider.
+  String get prefKey;
+}
+
+class _TextCaseFmtNotifierProviderElement
+    extends AutoDisposeAsyncNotifierProviderElement<TextCaseFmtNotifier,
+        TextCaseFmt> with TextCaseFmtNotifierRef {
+  _TextCaseFmtNotifierProviderElement(super.provider);
+
+  @override
+  String get prefKey => (origin as TextCaseFmtNotifierProvider).prefKey;
+}
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package

--- a/lib/services/providers/specimens.dart
+++ b/lib/services/providers/specimens.dart
@@ -12,7 +12,9 @@ import 'package:riverpod_annotation/riverpod_annotation.dart';
 part 'specimens.g.dart';
 
 const String specimenTypePrefKey = 'specimenTypes';
+const String specimenTypeFmtPrefKey = 'specimenTypeFmt';
 const String treatmentPrefKey = 'specimenTreatment';
+const String treatmentFmtPrefKey = 'treatmentFmt';
 const String catalogFmtPrefKey = 'catalogFmt';
 
 @riverpod

--- a/lib/services/utility_services.dart
+++ b/lib/services/utility_services.dart
@@ -46,12 +46,51 @@ bool isListContains(List<String> list, String value) {
   return list.any((e) => e.toLowerCase() == value.toLowerCase());
 }
 
+enum TextCaseFmt {
+  anyCase,
+  sentenceCase,
+  titleCase,
+  upperCase,
+  lowerCase,
+}
+
+Map<TextCaseFmt, String> textCaseFmtMap = {
+  TextCaseFmt.anyCase: 'Any Case',
+  TextCaseFmt.sentenceCase: 'Sentence Case',
+  TextCaseFmt.titleCase: 'Title Case',
+  TextCaseFmt.upperCase: 'Upper Case',
+  TextCaseFmt.lowerCase: 'Lower Case',
+};
+
 extension StringExtension on String {
   String toSentenceCase() {
     try {
       return '${this[0].toUpperCase()}${substring(1).toLowerCase()}';
     } catch (e) {
       return '';
+    }
+  }
+
+  String toTitleCase() {
+    try {
+      return split(' ').map((word) => word.toSentenceCase()).join(' ');
+    } catch (e) {
+      return '';
+    }
+  }
+
+  String toTextCaseFmt(TextCaseFmt textCaseFmt) {
+    switch (textCaseFmt) {
+      case TextCaseFmt.anyCase:
+        return this;
+      case TextCaseFmt.sentenceCase:
+        return toSentenceCase();
+      case TextCaseFmt.titleCase:
+        return toTitleCase();
+      case TextCaseFmt.lowerCase:
+        return toLowerCase();
+      case TextCaseFmt.upperCase:
+        return toUpperCase();
     }
   }
 }


### PR DESCRIPTION
- Adds a `TextCaseFmt` enum and associated helper methods to easily format text fields to `Sentence case`, `Title Case`, `UPPER CASE` or `lower case`. 
- Creates an async notifier family for text format preferences (this was probably overkill, but it provided a flexible, single provider that accepts a preference key and facilitated splitting the format dropdown widgets from the custom setting widgets).
- Creates "Format" setting blocks in the Specimen and Collection Events settings pages that contain new dropdowns for text formatting.
- Dynamically formats new custom dropdown values based on text format setting for the following:
  - Specimen types
  - Treatments
  - Collection methods
  - Personnel roles

Once #21 is complete this can easily be extended there.

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/0725cdce-46a4-4886-ad7f-4fa7565b32fb" />

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/8f464f5e-1997-4c82-b93b-7f0173159767" />



This resolves #32