### PR TITLE
Migrate date and time fields to standard formats

### DIFF
--- a/lib/screens/projects/components/project_form.dart
+++ b/lib/screens/projects/components/project_form.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:drift/drift.dart' as db;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:intl/intl.dart';
 import 'package:nahpu/services/providers/specimens.dart';
 import 'package:nahpu/services/types/controllers.dart';
 import 'package:nahpu/services/project_services.dart';
@@ -151,7 +150,7 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
                       );
                       if (selectedDate != null) {
                         widget.projectCtr.startDateCtr.text =
-                            DateFormat.yMMMd().format(selectedDate);
+                            dateTimeToDateDisplay(selectedDate);
                       }
                       _validateEditing();
                     },
@@ -172,7 +171,7 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
                       );
                       if (selectedDate != null) {
                         widget.projectCtr.endDateCtr.text =
-                            DateFormat.yMMMd().format(selectedDate);
+                            dateTimeToDateDisplay(selectedDate);
                       }
                       _validateEditing();
                     },
@@ -262,8 +261,8 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
       description: db.Value(widget.projectCtr.descriptionCtr.text),
       principalInvestigator: db.Value(widget.projectCtr.pICtr.text),
       location: db.Value(widget.projectCtr.locationCtr.text),
-      startDate: db.Value(widget.projectCtr.startDateCtr.text),
-      endDate: db.Value(widget.projectCtr.endDateCtr.text),
+      startDate: db.Value(dateDisplayToDateStd(widget.projectCtr.startDateCtr.text)),
+      endDate: db.Value(dateDisplayToDateStd(widget.projectCtr.endDateCtr.text)),
       created: db.Value(getSystemDateTime()),
       lastAccessed: db.Value(getSystemDateTime()),
     );
@@ -277,8 +276,8 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
       description: db.Value(widget.projectCtr.descriptionCtr.text),
       principalInvestigator: db.Value(widget.projectCtr.pICtr.text),
       location: db.Value(widget.projectCtr.locationCtr.text),
-      startDate: db.Value(widget.projectCtr.startDateCtr.text),
-      endDate: db.Value(widget.projectCtr.endDateCtr.text),
+      startDate: db.Value(dateDisplayToDateStd(widget.projectCtr.startDateCtr.text)),
+      endDate: db.Value(dateDisplayToDateStd(widget.projectCtr.endDateCtr.text)),
       created: db.Value(getSystemDateTime()),
       lastAccessed: db.Value(getSystemDateTime()),
     );

--- a/lib/screens/projects/components/project_form.dart
+++ b/lib/screens/projects/components/project_form.dart
@@ -278,7 +278,7 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
       location: db.Value(widget.projectCtr.locationCtr.text),
       startDate: db.Value(dateDisplayToDateStd(widget.projectCtr.startDateCtr.text)),
       endDate: db.Value(dateDisplayToDateStd(widget.projectCtr.endDateCtr.text)),
-      created: db.Value(getSystemDateTime()),
+      created: db.Value(widget.projectCtr.createdCtr),
       lastAccessed: db.Value(getSystemDateTime()),
     );
 

--- a/lib/screens/projects/components/project_form.dart
+++ b/lib/screens/projects/components/project_form.dart
@@ -147,10 +147,10 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
                     onTap: () async {
                       DateTime? selectedDate = await _showDate(
                         context,
+                        widget.projectCtr.startDateCtr.dateTime
                       );
                       if (selectedDate != null) {
-                        widget.projectCtr.startDateCtr.text =
-                            dateTimeToDateDisplay(selectedDate);
+                        widget.projectCtr.startDateCtr.dateTime = selectedDate;
                       }
                       _validateEditing();
                     },
@@ -168,10 +168,11 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
                     onTap: () async {
                       DateTime? selectedDate = await _showDate(
                         context,
+                        widget.projectCtr.endDateCtr.dateTime
                       );
                       if (selectedDate != null) {
-                        widget.projectCtr.endDateCtr.text =
-                            dateTimeToDateDisplay(selectedDate);
+                        widget.projectCtr.endDateCtr.dateTime =
+                            selectedDate;
                       }
                       _validateEditing();
                     },
@@ -246,10 +247,10 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
     });
   }
 
-  Future<DateTime?> _showDate(BuildContext context) {
+  Future<DateTime?> _showDate(BuildContext context, DateTime? initialDate) {
     return showDatePicker(
         context: context,
-        initialDate: DateTime.now(),
+        initialDate: initialDate ?? DateTime.now(),
         firstDate: DateTime(2000),
         lastDate: DateTime(2030)); // Prevent user from selecting future dates
   }
@@ -261,8 +262,8 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
       description: db.Value(widget.projectCtr.descriptionCtr.text),
       principalInvestigator: db.Value(widget.projectCtr.pICtr.text),
       location: db.Value(widget.projectCtr.locationCtr.text),
-      startDate: db.Value(dateDisplayToDateStd(widget.projectCtr.startDateCtr.text)),
-      endDate: db.Value(dateDisplayToDateStd(widget.projectCtr.endDateCtr.text)),
+      startDate: db.Value(widget.projectCtr.startDateCtr.date),
+      endDate: db.Value(widget.projectCtr.endDateCtr.date),
       created: db.Value(getSystemDateTime()),
       lastAccessed: db.Value(getSystemDateTime()),
     );
@@ -276,8 +277,8 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
       description: db.Value(widget.projectCtr.descriptionCtr.text),
       principalInvestigator: db.Value(widget.projectCtr.pICtr.text),
       location: db.Value(widget.projectCtr.locationCtr.text),
-      startDate: db.Value(dateDisplayToDateStd(widget.projectCtr.startDateCtr.text)),
-      endDate: db.Value(dateDisplayToDateStd(widget.projectCtr.endDateCtr.text)),
+      startDate: db.Value(widget.projectCtr.startDateCtr.date),
+      endDate: db.Value(widget.projectCtr.endDateCtr.date),
       created: db.Value(widget.projectCtr.createdCtr),
       lastAccessed: db.Value(getSystemDateTime()),
     );

--- a/lib/screens/projects/components/project_info.dart
+++ b/lib/screens/projects/components/project_info.dart
@@ -34,11 +34,11 @@ class ProjectInfo extends ConsumerWidget {
         ),
         ProjectInfoText(
           title: 'Start date: ',
-          text: projectData?.startDate,
+          text: dateStdToDateDisplay(projectData?.startDate),
         ),
         ProjectInfoText(
           title: 'End date: ',
-          text: projectData?.endDate,
+          text: dateStdToDateDisplay(projectData?.endDate),
         ),
         const SizedBox(height: 24),
         ProjectInfoText(

--- a/lib/services/database/database.dart
+++ b/lib/services/database/database.dart
@@ -153,27 +153,7 @@ class Database extends _$Database {
     await m.deleteTable('bird_measurement');
     await m.createTable(avianMeasurement);
 
-    _castMammalType(m);
-  }
-
-  Future<void> _castMammalType(Migrator m) async {
-    await m.alterTable(TableMigration(mammalMeasurement, columnTransformer: {
-      mammalMeasurement.totalLength:
-          mammalMeasurement.totalLength.cast<double>(),
-      mammalMeasurement.tailLength: mammalMeasurement.tailLength.cast<double>(),
-      mammalMeasurement.hindFootLength:
-          mammalMeasurement.hindFootLength.cast<double>(),
-      mammalMeasurement.earLength: mammalMeasurement.earLength.cast<double>(),
-      mammalMeasurement.forearm: mammalMeasurement.forearm.cast<double>(),
-      mammalMeasurement.testisLength:
-          mammalMeasurement.testisLength.cast<double>(),
-      mammalMeasurement.testisWidth:
-          mammalMeasurement.testisWidth.cast<double>(),
-    }));
-  }
-
-  Future<void> addColumnToTable(String tableName, String columnName) async {
-    await customStatement('ALTER TABLE $tableName ADD COLUMN $columnName');
+    castMammalType(m);
   }
 
   Future<void> exportInto(File file) async {

--- a/lib/services/database/database.dart
+++ b/lib/services/database/database.dart
@@ -4,6 +4,7 @@ import 'package:drift/drift.dart';
 import 'package:drift/native.dart';
 import 'package:flutter/foundation.dart';
 import 'package:nahpu/services/io_services.dart';
+import 'package:nahpu/services/database/migration_utilities.dart';
 import 'package:path/path.dart' as p;
 
 part 'database.g.dart';
@@ -67,9 +68,12 @@ class Database extends _$Database {
     });
   }
 
-  Future<void> _migrateFromVersion5(Migrator m) async {  
+  Future<void> _migrateFromVersion5(Migrator m) async {
     // Specimen record tables
     await m.addColumn(specimen, specimen.collectionDate);
+
+    // Date and time format changes
+    await migrateProjectDatesFormat(m);
   }
 
   Future<void> _migrateFromVersion4(Migrator m) async {
@@ -78,7 +82,7 @@ class Database extends _$Database {
     // Specimen record tables
     await m.addColumn(specimen, specimen.iDConfidence);
     await m.addColumn(specimen, specimen.iDMethod);
-    
+
     await m.addColumn(specimenPart, specimenPart.personnelId);
     await m.addColumn(specimenPart, specimenPart.pmi);
 

--- a/lib/services/database/migration_utilities.dart
+++ b/lib/services/database/migration_utilities.dart
@@ -3,6 +3,22 @@ import 'package:nahpu/services/database/database.dart';
 import 'package:nahpu/services/database/project_queries.dart';
 import 'package:intl/intl.dart';
 
+Future<void> castMammalType(Migrator m) async {
+  final mammalMeasurement = (m.database as Database).mammalMeasurement;
+
+  await m.alterTable(TableMigration(mammalMeasurement, columnTransformer: {
+    mammalMeasurement.totalLength: mammalMeasurement.totalLength.cast<double>(),
+    mammalMeasurement.tailLength: mammalMeasurement.tailLength.cast<double>(),
+    mammalMeasurement.hindFootLength:
+        mammalMeasurement.hindFootLength.cast<double>(),
+    mammalMeasurement.earLength: mammalMeasurement.earLength.cast<double>(),
+    mammalMeasurement.forearm: mammalMeasurement.forearm.cast<double>(),
+    mammalMeasurement.testisLength:
+        mammalMeasurement.testisLength.cast<double>(),
+    mammalMeasurement.testisWidth: mammalMeasurement.testisWidth.cast<double>(),
+  }));
+}
+
 String convertDateString(String inputDateString) {
   DateTime? parsedDate = DateFormat.yMMMd().tryParse(inputDateString);
   if (parsedDate == null) return inputDateString;

--- a/lib/services/database/migration_utilities.dart
+++ b/lib/services/database/migration_utilities.dart
@@ -1,0 +1,41 @@
+import 'package:drift/drift.dart';
+import 'package:nahpu/services/database/database.dart';
+import 'package:nahpu/services/database/project_queries.dart';
+import 'package:intl/intl.dart';
+
+String convertDateString(String inputDateString) {
+  DateTime? parsedDate = DateFormat.yMMMd().tryParse(inputDateString);
+  if (parsedDate == null) return inputDateString;
+  return DateFormat('yyyy-MM-dd').format(parsedDate);
+}
+
+Future<void> migrateProjectDatesFormat(Migrator m) async {
+  final db = m.database as Database;
+
+  final fieldsToUpdate = ['startDate', 'endDate'];
+  final projects = await ProjectQuery(db).getAllProjects();
+
+  for (final projectData in projects) {
+    bool doUpdate = false;
+    final projectJson = projectData.toJson();
+
+    for (final field in fieldsToUpdate) {
+      final dateString = projectJson[field];
+
+      if (dateString != null && dateString.isNotEmpty) {
+        final updatedDateString = convertDateString(dateString);
+
+        if (updatedDateString != dateString) {
+          doUpdate = true;
+          projectJson[field] = updatedDateString;
+        }
+      }
+    }
+
+    if (doUpdate) {
+      final updatedProjectData = ProjectData.fromJson(projectJson);
+      ProjectQuery(db).updateProjectEntry(
+          updatedProjectData.uuid, updatedProjectData.toCompanion(false));
+    }
+  }
+}

--- a/lib/services/types/controllers.dart
+++ b/lib/services/types/controllers.dart
@@ -3,6 +3,31 @@ import 'package:nahpu/services/types/export.dart';
 import 'package:nahpu/services/database/database.dart';
 import 'package:nahpu/services/utility_services.dart';
 
+class DateEditingController extends TextEditingController {
+  DateTime? _dateTime;
+  String? _date;
+
+  DateEditingController({String? date}) : 
+    _date = date,
+    _dateTime = dateStdToDateTime(date),
+    super(text: dateStdToDateDisplay(date));
+
+  String? get date => _date;    
+  DateTime? get dateTime => _dateTime;
+
+  set dateTime(DateTime? newDate) {
+    _dateTime = newDate;
+    _date = dateTimeToDateStd(newDate);
+    text = dateTimeToDateDisplay(_dateTime);
+  }
+
+  set date(String? newDate) {
+    _date = newDate;
+    _dateTime = dateStdToDateTime(newDate);
+    text = dateTimeToDateDisplay(_dateTime);
+  }
+}
+
 class ProjectFormCtrModel {
   ProjectFormCtrModel({
     required this.projectNameCtr,
@@ -18,8 +43,8 @@ class ProjectFormCtrModel {
   TextEditingController descriptionCtr;
   TextEditingController pICtr;
   TextEditingController locationCtr;
-  TextEditingController startDateCtr;
-  TextEditingController endDateCtr;
+  DateEditingController startDateCtr;
+  DateEditingController endDateCtr;
   String? createdCtr;
 
   factory ProjectFormCtrModel.empty() => ProjectFormCtrModel(
@@ -27,8 +52,8 @@ class ProjectFormCtrModel {
         descriptionCtr: TextEditingController(),
         pICtr: TextEditingController(),
         locationCtr: TextEditingController(),
-        startDateCtr: TextEditingController(),
-        endDateCtr: TextEditingController(),
+        startDateCtr: DateEditingController(),
+        endDateCtr: DateEditingController(),
         createdCtr: null,
       );
 
@@ -38,8 +63,8 @@ class ProjectFormCtrModel {
         descriptionCtr: TextEditingController(text: data?.description ?? ''),
         pICtr: TextEditingController(text: data?.principalInvestigator ?? ''),
         locationCtr: TextEditingController(text: data?.location ?? ''),
-        startDateCtr: TextEditingController(text: dateStdToDateDisplay(data?.startDate)),
-        endDateCtr: TextEditingController(text: dateStdToDateDisplay(data?.endDate)),
+        startDateCtr: DateEditingController(date: data?.startDate),
+        endDateCtr: DateEditingController(date: data?.endDate),
         createdCtr: data?.created,
       );
 
@@ -48,8 +73,8 @@ class ProjectFormCtrModel {
     descriptionCtr.text = data.description ?? '';
     pICtr.text = data.principalInvestigator ?? '';
     locationCtr.text = data.location ?? '';
-    startDateCtr.text = data.startDate ?? '';
-    endDateCtr.text = data.endDate ?? '';
+    startDateCtr.date = data.startDate ?? '';
+    endDateCtr.date = data.endDate ?? '';
     createdCtr = data.created ?? '';
   }
 

--- a/lib/services/types/controllers.dart
+++ b/lib/services/types/controllers.dart
@@ -35,8 +35,8 @@ class ProjectFormCtrModel {
         descriptionCtr: TextEditingController(text: data?.description ?? ''),
         pICtr: TextEditingController(text: data?.principalInvestigator ?? ''),
         locationCtr: TextEditingController(text: data?.location ?? ''),
-        startDateCtr: TextEditingController(text: data?.startDate ?? ''),
-        endDateCtr: TextEditingController(text: data?.endDate ?? ''),
+        startDateCtr: TextEditingController(text: dateStdToDateDisplay(data?.startDate)),
+        endDateCtr: TextEditingController(text: dateStdToDateDisplay(data?.endDate)),
       );
 
   void updateData(ProjectData data) {

--- a/lib/services/types/controllers.dart
+++ b/lib/services/types/controllers.dart
@@ -11,6 +11,7 @@ class ProjectFormCtrModel {
     required this.locationCtr,
     required this.startDateCtr,
     required this.endDateCtr,
+    required this.createdCtr,
   });
 
   TextEditingController projectNameCtr;
@@ -19,6 +20,7 @@ class ProjectFormCtrModel {
   TextEditingController locationCtr;
   TextEditingController startDateCtr;
   TextEditingController endDateCtr;
+  String? createdCtr;
 
   factory ProjectFormCtrModel.empty() => ProjectFormCtrModel(
         projectNameCtr: TextEditingController(),
@@ -27,6 +29,7 @@ class ProjectFormCtrModel {
         locationCtr: TextEditingController(),
         startDateCtr: TextEditingController(),
         endDateCtr: TextEditingController(),
+        createdCtr: null,
       );
 
   factory ProjectFormCtrModel.fromData(ProjectData? data) =>
@@ -37,6 +40,7 @@ class ProjectFormCtrModel {
         locationCtr: TextEditingController(text: data?.location ?? ''),
         startDateCtr: TextEditingController(text: dateStdToDateDisplay(data?.startDate)),
         endDateCtr: TextEditingController(text: dateStdToDateDisplay(data?.endDate)),
+        createdCtr: data?.created,
       );
 
   void updateData(ProjectData data) {
@@ -46,6 +50,7 @@ class ProjectFormCtrModel {
     locationCtr.text = data.location ?? '';
     startDateCtr.text = data.startDate ?? '';
     endDateCtr.text = data.endDate ?? '';
+    createdCtr = data.created ?? '';
   }
 
   void dispose() {

--- a/lib/services/utility_services.dart
+++ b/lib/services/utility_services.dart
@@ -29,6 +29,38 @@ String getSystemDateTime() {
   return (date: formattedDate, time: formattedTime);
 }
 
+// Given a datetime, format it for display to the user (yMMMd)
+String dateTimeToDateDisplay(DateTime inputDateTime) {
+  return DateFormat.yMMMd().format(inputDateTime);
+}
+
+// Given a datetime, format it for storage (yyyy-MM-dd)
+String dateTimeToDateStd(DateTime inputDateTime) {
+  return DateFormat('yyyy-MM-dd').format(inputDateTime);
+}
+
+// Given a date string in the standard storage format (yyyy-MM-dd)
+// return a string in the standard display format (yMMMd)
+String dateStdToDateDisplay(String? inputDateString) {
+  if (inputDateString == null) return '';
+
+  DateTime? parsedDate = DateFormat('yyyy-MM-dd').tryParse(inputDateString);
+  if (parsedDate == null) return '';
+
+  return DateFormat.yMMMd().format(parsedDate);
+}
+
+// Given a displayed date string (yMMMd format), format it for DB storage (yyyy-MM-dd)
+String dateDisplayToDateStd(String? inputDateString) {
+  if (inputDateString == null) return '';
+
+  DateTime? parsedDate = DateFormat.yMMMd().tryParse(inputDateString);
+
+  if (parsedDate == null) return '';
+
+  return DateFormat('yyyy-MM-dd').format(parsedDate);
+}
+
 // Insert only unique values
 List<String> getDistinctList(List<String?> list) {
   // Get unique value and remove empty string

--- a/lib/services/utility_services.dart
+++ b/lib/services/utility_services.dart
@@ -30,24 +30,38 @@ String getSystemDateTime() {
 }
 
 // Given a datetime, format it for display to the user (yMMMd)
-String dateTimeToDateDisplay(DateTime inputDateTime) {
+String dateTimeToDateDisplay(DateTime? inputDateTime) {
+  if (inputDateTime == null) return '';
   return DateFormat.yMMMd().format(inputDateTime);
 }
 
 // Given a datetime, format it for storage (yyyy-MM-dd)
-String dateTimeToDateStd(DateTime inputDateTime) {
+String dateTimeToDateStd(DateTime? inputDateTime) {
+  if (inputDateTime == null) return '';
   return DateFormat('yyyy-MM-dd').format(inputDateTime);
 }
 
 // Given a date string in the standard storage format (yyyy-MM-dd)
 // return a string in the standard display format (yMMMd)
-String dateStdToDateDisplay(String? inputDateString) {
+String? dateStdToDateDisplay(String? inputDateString) {
   if (inputDateString == null) return '';
 
   DateTime? parsedDate = DateFormat('yyyy-MM-dd').tryParse(inputDateString);
   if (parsedDate == null) return '';
 
   return DateFormat.yMMMd().format(parsedDate);
+}
+
+// Given a date string in the display format (yMMMd) return a DateTime
+DateTime? dateDisplayToDateTime(String? inputDateString) {
+  if (inputDateString == null) return null;
+  return DateFormat.yMMMd().tryParse(inputDateString);
+}
+
+// Given a date string in the standard format (yyyy-MM-dd) return a DateTime
+DateTime? dateStdToDateTime(String? inputDateString) {
+  if (inputDateString == null) return null;
+  return DateFormat('yyyy-MM-dd').tryParse(inputDateString);
 }
 
 // Given a displayed date string (yMMMd format), format it for DB storage (yyyy-MM-dd)


### PR DESCRIPTION
@hhandika this PR is a draft showing my approach for the date/time standardization. It's limited to only project start and end dates for right now. If this approach looks good, I'll apply it to the other date fields noted in #46 and work on a similar approach for time fields.

- Migrates date fields in the app to store dates in the standard `yyyy-MM-dd` format.
- Adds several utility functions to swap between stored date strings in the standard format, DateTime objects, and date strings in the display `yMMMd` format.
- Adds a `DateEditingController` extending `TextEditingController` that attempts to abstract away the need to think about date formats in widget date fields.
- Adds support for date pickers to retain the user-set value on open now that we have a standard date format.
- A couple bug fixes and migration reorgs to hopefully keep things organized.