### PR TITLE
Standardize date fields

### DIFF
--- a/lib/screens/events/components/general_info.dart
+++ b/lib/screens/events/components/general_info.dart
@@ -99,7 +99,7 @@ class EventInfoFieldState extends ConsumerState<EventInfoField> {
                     widget.collEventId,
                     CollEventCompanion(
                       startDate:
-                          db.Value(widget.collEventCtr.startDateCtr.text),
+                          db.Value(widget.collEventCtr.startDateCtr.date),
                     ),
                   );
                 },
@@ -172,7 +172,7 @@ class EndDateField extends ConsumerWidget {
         CollEventServices(ref: ref).updateCollEvent(
           collEventId,
           CollEventCompanion(
-            endDate: db.Value(collEventCtr.endDateCtr.text),
+            endDate: db.Value(collEventCtr.endDateCtr.date),
           ),
         );
       },
@@ -180,7 +180,7 @@ class EndDateField extends ConsumerWidget {
         CollEventServices(ref: ref).updateCollEvent(
           collEventId,
           CollEventCompanion(
-            startDate: db.Value(null),
+            endDate: db.Value(null),
           ),
         );
       }      

--- a/lib/screens/narrative/components/top_forms.dart
+++ b/lib/screens/narrative/components/top_forms.dart
@@ -59,7 +59,7 @@ class DateForm extends ConsumerWidget {
       onTap: () {
         NarrativeServices(ref: ref).updateNarrative(
           narrativeId,
-          NarrativeCompanion(date: db.Value(narrativeCtr.dateCtr.text)),
+          NarrativeCompanion(date: db.Value(narrativeCtr.dateCtr.date)),
         );
       },
       onClear: () {

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -200,7 +200,7 @@ class NarrativePages extends StatelessWidget {
   NarrativeFormCtrModel _updateController(
       List<NarrativeData> narrativeEntries, int index) {
     return NarrativeFormCtrModel(
-      dateCtr: TextEditingController(text: narrativeEntries[index].date),
+      dateCtr: DateEditingController(date: narrativeEntries[index].date),
       siteCtr: narrativeEntries[index].siteID,
       narrativeCtr:
           TextEditingController(text: narrativeEntries[index].narrative),

--- a/lib/screens/shared/fields.dart
+++ b/lib/screens/shared/fields.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:nahpu/services/types/controllers.dart';
 
 class CommonDateField extends ConsumerStatefulWidget {
   const CommonDateField({
@@ -15,7 +15,7 @@ class CommonDateField extends ConsumerStatefulWidget {
     required this.onClear,
   });
 
-  final TextEditingController controller;
+  final DateEditingController controller;
   final String labelText;
   final String hintText;
   final DateTime initialDate;
@@ -40,19 +40,19 @@ class CommonDateFieldState extends ConsumerState<CommonDateField> {
         final selectedDate = await showDatePicker(
             context: context,
             cancelText: "Clear",
-            initialDate: widget.initialDate,
+            initialDate: widget.controller.dateTime ?? widget.initialDate,
             firstDate: DateTime(2000),
             lastDate: widget.lastDate);
 
         // OK pressed
         if (selectedDate != null && mounted) {
-          widget.controller.text = DateFormat.yMMMd().format(selectedDate);
+          widget.controller.dateTime = selectedDate;
           widget.onTap();
         }
 
         // Clear pressed (or picker closed)
         if (selectedDate == null && mounted) {
-          widget.controller.text = "";
+          widget.controller.dateTime = null;
           widget.onClear();
         }
       },

--- a/lib/screens/specimens/shared/associated_data.dart
+++ b/lib/screens/specimens/shared/associated_data.dart
@@ -144,7 +144,7 @@ class AssociateDataItem extends StatelessWidget {
 
   String get _subtitle {
     final type = data.type ?? '';
-    final date = _getText(data.date);
+    final date = _getText(dateStdToDateDisplay(data.date));
     return '$type$date';
   }
 
@@ -477,7 +477,7 @@ class AssociatedDataFormState extends ConsumerState<AssociatedDataForm> {
       specimenUuid: db.Value(widget.specimenUuid),
       name: db.Value(widget.ctr.nameCtr.text),
       type: db.Value(widget.ctr.typeCtr),
-      date: db.Value(widget.ctr.dateCtr.text),
+      date: db.Value(widget.ctr.dateCtr.date),
       description: db.Value(widget.ctr.descriptionCtr.text),
       url: db.Value(widget.ctr.urlCtr.text),
     );

--- a/lib/screens/specimens/shared/capture_records.dart
+++ b/lib/screens/specimens/shared/capture_records.dart
@@ -495,7 +495,7 @@ class CaptureDate extends ConsumerWidget {
         SpecimenServices(ref: ref).updateSpecimen(
           specimenUuid,
           SpecimenCompanion(
-            captureDate: db.Value(specimenCtr.captureDateCtr.text),
+            captureDate: db.Value(specimenCtr.captureDateCtr.date),
           ),
         );
       },

--- a/lib/screens/specimens/shared/general_records.dart
+++ b/lib/screens/specimens/shared/general_records.dart
@@ -241,7 +241,7 @@ class SpecimenCollectionDateField extends ConsumerWidget {
           specimenUuid,
           SpecimenCompanion(
             collectionDate: db.Value(
-              specimenCtr.collDateCtr.text,
+              specimenCtr.collDateCtr.date,
             )
           ),
         );
@@ -355,7 +355,7 @@ class PrepDateField extends ConsumerWidget {
         SpecimenServices(ref: ref).updateSpecimen(
           specimenUuid,
           SpecimenCompanion(
-            prepDate: db.Value(specimenCtr.prepDateCtr.text),
+            prepDate: db.Value(specimenCtr.prepDateCtr.date),
           ),
         );
       },

--- a/lib/screens/specimens/shared/specimen_parts.dart
+++ b/lib/screens/specimens/shared/specimen_parts.dart
@@ -377,7 +377,7 @@ class PartSubTitle extends StatelessWidget {
       '${_getTextFirst(part.tissueID)}'
       '$treatment'
       '${_getText(part.additionalTreatment)}'
-      '${_getText(part.dateTaken)}'
+      '${_getText(dateStdToDateDisplay(part.dateTaken))}'
       '${_getText(part.timeTaken)}'
       '${_getPMI()}'
       '$remark',
@@ -592,7 +592,7 @@ class PartFormState extends ConsumerState<PartForm> {
       count: db.Value(widget.partCtr.countCtr.text),
       treatment: db.Value(widget.partCtr.treatmentCtr.text),
       additionalTreatment: db.Value(widget.partCtr.additionalTreatmentCtr.text),
-      dateTaken: db.Value(widget.partCtr.dateTakenCtr.text),
+      dateTaken: db.Value(widget.partCtr.dateTakenCtr.date),
       timeTaken: db.Value(widget.partCtr.timeTakenCtr.text),
       pmi: db.Value(widget.partCtr.pmiCtr.text),
       museumPermanent: db.Value(widget.partCtr.museumPermanentCtr.text),

--- a/lib/services/database/database.dart
+++ b/lib/services/database/database.dart
@@ -70,7 +70,7 @@ class Database extends _$Database {
 
   Future<void> _migrateFromVersion5(Migrator m) async {
     // Specimen record tables
-    // await m.addColumn(specimen, specimen.collectionDate);
+    await m.addColumn(specimen, specimen.collectionDate);
 
     // Date and time format changes
     await migrateProjectDatesFormat(m);

--- a/lib/services/database/database.dart
+++ b/lib/services/database/database.dart
@@ -70,10 +70,13 @@ class Database extends _$Database {
 
   Future<void> _migrateFromVersion5(Migrator m) async {
     // Specimen record tables
-    await m.addColumn(specimen, specimen.collectionDate);
+    // await m.addColumn(specimen, specimen.collectionDate);
 
     // Date and time format changes
     await migrateProjectDatesFormat(m);
+    await migrateSpecimenDatesFormat(m);
+    await migrateNarrativeDatesFormat(m);
+    await migrateCollEventDatesFormat(m);
   }
 
   Future<void> _migrateFromVersion4(Migrator m) async {

--- a/lib/services/database/migration_utilities.dart
+++ b/lib/services/database/migration_utilities.dart
@@ -1,6 +1,9 @@
 import 'package:drift/drift.dart';
+import 'package:nahpu/services/database/collevent_queries.dart';
 import 'package:nahpu/services/database/database.dart';
 import 'package:nahpu/services/database/project_queries.dart';
+import 'package:nahpu/services/database/specimen_queries.dart';
+import 'package:nahpu/services/database/narrative_queries.dart';
 import 'package:intl/intl.dart';
 
 Future<void> castMammalType(Migrator m) async {
@@ -52,6 +55,148 @@ Future<void> migrateProjectDatesFormat(Migrator m) async {
       final updatedProjectData = ProjectData.fromJson(projectJson);
       ProjectQuery(db).updateProjectEntry(
           updatedProjectData.uuid, updatedProjectData.toCompanion(false));
+    }
+  }
+}
+
+Future<void> migrateSpecimenDatesFormat(Migrator m) async {
+  final db = m.database as Database;
+
+  final specimenFieldsToUpdate = ['prepDate', 'collectionDate', 'captureDate'];
+  final projects = await ProjectQuery(db).getAllProjects();
+
+  for (final projectData in projects) {
+    final specimens = await SpecimenQuery(db).getAllSpecimens(projectData.uuid);
+
+    for (final specimenData in specimens) {
+      // Specimen general records and capture records update
+      bool doSpecimenUpdate = false;
+      final specimenJson = specimenData.toJson();
+
+      for (final field in specimenFieldsToUpdate) {
+        final dateString = specimenJson[field];
+
+        if (dateString != null && dateString.isNotEmpty) {
+          final updatedDateString = convertDateString(dateString);
+
+          if (updatedDateString != dateString) {
+            doSpecimenUpdate = true;
+            specimenJson[field] = updatedDateString;
+          }
+        }
+      }
+
+      if (doSpecimenUpdate) {
+        final updatedSpecimenData = SpecimenData.fromJson(specimenJson);
+        SpecimenQuery(db).updateSpecimenEntry(
+            updatedSpecimenData.uuid, updatedSpecimenData.toCompanion(false));
+      }
+
+      // Specimen part update
+      final specimenParts =
+          await SpecimenPartQuery(db).getSpecimenParts(specimenData.uuid);
+
+      for (final specimenPartData in specimenParts) {
+        final specimenPartJson = specimenPartData.toJson();
+        final dateString = specimenPartJson['dateTaken'];
+
+        if (dateString != null && dateString.isNotEmpty) {
+          final updatedDateString = convertDateString(dateString);
+
+          if (updatedDateString != dateString) {
+            specimenPartJson['dateTaken'] = updatedDateString;
+            final updatedSpecimenPartData =
+                SpecimenPartData.fromJson(specimenPartJson);
+            SpecimenPartQuery(db).updateSpecimenPart(
+                updatedSpecimenPartData.id as int,
+                updatedSpecimenPartData.toCompanion(false));
+          }
+        }
+      }
+
+      // Associated data update
+      final associatedDataList =
+          await AssociatedDataQuery(db).getAllAssociatedData(specimenData.uuid);
+
+      for (final associatedDatum in associatedDataList) {
+        final associatedDatumJson = associatedDatum.toJson();
+        final dateString = associatedDatumJson['date'];
+
+        if (dateString != null && dateString.isNotEmpty) {
+          final updatedDateString = convertDateString(dateString);
+
+          if (updatedDateString != dateString) {
+            associatedDatumJson['date'] = updatedDateString;
+            final updatedAssociatedDatum =
+                AssociatedDataData.fromJson(associatedDatumJson);
+            AssociatedDataQuery(db).updateAssociatedData(
+                updatedAssociatedDatum.primaryId as int,
+                updatedAssociatedDatum.toCompanion(false));
+          }
+        }
+      }
+    }
+  }
+}
+
+Future<void> migrateNarrativeDatesFormat(Migrator m) async {
+  final db = m.database as Database;
+  final projects = await ProjectQuery(db).getAllProjects();
+
+  for (final projectData in projects) {
+    final narrativeList =
+        await NarrativeQuery(db).getAllNarrative(projectData.uuid);
+
+    for (final narrativeData in narrativeList) {
+      final narrativeJson = narrativeData.toJson();
+      final dateString = narrativeJson['date'];
+
+      if (dateString != null && dateString.isNotEmpty) {
+        final updatedDateString = convertDateString(dateString);
+
+        if (updatedDateString != dateString) {
+          narrativeJson['date'] = updatedDateString;
+          final updatedNarrativeData = NarrativeData.fromJson(narrativeJson);
+          NarrativeQuery(db).updateNarrativeEntry(
+              updatedNarrativeData.id, updatedNarrativeData.toCompanion(false));
+        }
+      }
+    }
+  }
+}
+
+Future<void> migrateCollEventDatesFormat(Migrator m) async {
+  final db = m.database as Database;
+  final projects = await ProjectQuery(db).getAllProjects();
+
+  final collEventFieldsToUpdate = ['startDate', 'endDate'];
+
+  for (final projectData in projects) {
+    final eventList =
+        await CollEventQuery(db).getAllCollEvents(projectData.uuid);
+
+    for (final eventData in eventList) {
+      bool doUpdate = false;
+      final eventJson = eventData.toJson();
+
+      for (final field in collEventFieldsToUpdate) {
+        final dateString = eventJson[field];
+
+        if (dateString != null && dateString.isNotEmpty) {
+          final updatedDateString = convertDateString(dateString);
+
+          if (updatedDateString != dateString) {
+            doUpdate = true;
+            eventJson[field] = updatedDateString;
+          }
+        }
+      }
+
+      if (doUpdate) {
+        final updatedEventData = CollEventData.fromJson(eventJson);
+        CollEventQuery(db).updateCollEventEntry(
+            updatedEventData.id, updatedEventData.toCompanion(false));
+      }
     }
   }
 }

--- a/lib/services/types/controllers.dart
+++ b/lib/services/types/controllers.dart
@@ -175,8 +175,8 @@ class CollEventFormCtrModel {
 
   int? siteIDCtr;
   TextEditingController idSuffixCtr;
-  TextEditingController startDateCtr;
-  TextEditingController endDateCtr;
+  DateEditingController startDateCtr;
+  DateEditingController endDateCtr;
   TextEditingController startTimeCtr;
   TextEditingController endTimeCtr;
   String? primaryCollMethodCtr;
@@ -185,8 +185,8 @@ class CollEventFormCtrModel {
   factory CollEventFormCtrModel.empty() => CollEventFormCtrModel(
         siteIDCtr: null,
         idSuffixCtr: TextEditingController(),
-        startDateCtr: TextEditingController(),
-        endDateCtr: TextEditingController(),
+        startDateCtr: DateEditingController(),
+        endDateCtr: DateEditingController(),
         startTimeCtr: TextEditingController(),
         endTimeCtr: TextEditingController(),
         primaryCollMethodCtr: null,
@@ -197,8 +197,8 @@ class CollEventFormCtrModel {
       CollEventFormCtrModel(
         siteIDCtr: collEvent.siteID,
         idSuffixCtr: TextEditingController(text: collEvent.idSuffix),
-        startDateCtr: TextEditingController(text: collEvent.startDate),
-        endDateCtr: TextEditingController(text: collEvent.endDate),
+        startDateCtr: DateEditingController(date: collEvent.startDate),
+        endDateCtr: DateEditingController(date: collEvent.endDate),
         startTimeCtr: TextEditingController(text: collEvent.startTime),
         endTimeCtr: TextEditingController(text: collEvent.endTime),
         primaryCollMethodCtr: collEvent.primaryCollMethod,
@@ -221,12 +221,12 @@ class NarrativeFormCtrModel {
     required this.siteCtr,
     required this.narrativeCtr,
   });
-  TextEditingController dateCtr;
+  DateEditingController dateCtr;
   int? siteCtr;
   TextEditingController narrativeCtr;
 
   factory NarrativeFormCtrModel.empty() => NarrativeFormCtrModel(
-      dateCtr: TextEditingController(),
+      dateCtr: DateEditingController(),
       siteCtr: null,
       narrativeCtr: TextEditingController());
 
@@ -276,11 +276,11 @@ class SpecimenFormCtrModel {
   TextEditingController idMethodCtr;
   TextEditingController museumIDCtr;
   TextEditingController fieldNumberCtr;
-  TextEditingController prepDateCtr;
+  DateEditingController prepDateCtr;
   TextEditingController prepTimeCtr;
-  TextEditingController collDateCtr;
+  DateEditingController collDateCtr;
   TextEditingController collTimeCtr;
-  TextEditingController captureDateCtr;
+  DateEditingController captureDateCtr;
   TextEditingController captureTimeCtr;
   TextEditingController trapTypeCtr;
   TextEditingController methodIDCtr;
@@ -300,11 +300,11 @@ class SpecimenFormCtrModel {
         idConfidenceCtr: null,
         idMethodCtr: TextEditingController(),
         museumIDCtr: TextEditingController(),
-        prepDateCtr: TextEditingController(),
+        prepDateCtr: DateEditingController(),
         prepTimeCtr: TextEditingController(),
-        collDateCtr: TextEditingController(),
+        collDateCtr: DateEditingController(),
         collTimeCtr: TextEditingController(),
-        captureDateCtr: TextEditingController(),
+        captureDateCtr: DateEditingController(),
         captureTimeCtr: TextEditingController(),
         trapTypeCtr: TextEditingController(),
         methodIDCtr: TextEditingController(),
@@ -327,11 +327,11 @@ class SpecimenFormCtrModel {
         fieldNumberCtr:
             TextEditingController(text: specimen.fieldNumber?.toString() ?? ''),
         speciesCtr: specimen.speciesID,
-        prepDateCtr: TextEditingController(text: specimen.prepDate),
+        prepDateCtr: DateEditingController(date: specimen.prepDate),
         prepTimeCtr: TextEditingController(text: specimen.prepTime),
-        collDateCtr: TextEditingController(text: specimen.collectionDate),
+        collDateCtr: DateEditingController(date: specimen.collectionDate),
         collTimeCtr: TextEditingController(text: specimen.collectionTime),
-        captureDateCtr: TextEditingController(text: specimen.captureDate),
+        captureDateCtr: DateEditingController(date: specimen.captureDate),
         captureTimeCtr: TextEditingController(text: specimen.captureTime),
         trapTypeCtr: TextEditingController(text: specimen.trapType),
         methodIDCtr: TextEditingController(text: specimen.methodID ?? ''),
@@ -717,7 +717,7 @@ class PartFormCtrModel {
   TextEditingController countCtr;
   TextEditingController treatmentCtr;
   TextEditingController additionalTreatmentCtr;
-  TextEditingController dateTakenCtr;
+  DateEditingController dateTakenCtr;
   TextEditingController timeTakenCtr;
   TextEditingController pmiCtr;
   TextEditingController museumPermanentCtr;
@@ -732,7 +732,7 @@ class PartFormCtrModel {
         countCtr: TextEditingController(),
         treatmentCtr: TextEditingController(),
         additionalTreatmentCtr: TextEditingController(),
-        dateTakenCtr: TextEditingController(),
+        dateTakenCtr: DateEditingController(),
         timeTakenCtr: TextEditingController(),
         pmiCtr: TextEditingController(),
         museumPermanentCtr: TextEditingController(),
@@ -749,7 +749,7 @@ class PartFormCtrModel {
         treatmentCtr: TextEditingController(text: data.treatment ?? ''),
         additionalTreatmentCtr:
             TextEditingController(text: data.additionalTreatment ?? ''),
-        dateTakenCtr: TextEditingController(text: data.dateTaken ?? ''),
+        dateTakenCtr: DateEditingController(date: data.dateTaken ?? ''),
         timeTakenCtr: TextEditingController(text: data.timeTaken ?? ''),
         pmiCtr: TextEditingController(text: data.pmi ?? ''),
         museumPermanentCtr:
@@ -1192,14 +1192,14 @@ class AssociatedDataCtr {
   final TextEditingController nameCtr;
   String? typeCtr;
   final TextEditingController descriptionCtr;
-  final TextEditingController dateCtr;
+  final DateEditingController dateCtr;
   final TextEditingController urlCtr;
 
   factory AssociatedDataCtr.empty() => AssociatedDataCtr(
         nameCtr: TextEditingController(),
         typeCtr: null,
         descriptionCtr: TextEditingController(),
-        dateCtr: TextEditingController(),
+        dateCtr: DateEditingController(),
         urlCtr: TextEditingController(),
       );
 
@@ -1208,7 +1208,7 @@ class AssociatedDataCtr {
         nameCtr: TextEditingController(text: data.name ?? ''),
         typeCtr: data.type,
         descriptionCtr: TextEditingController(text: data.description ?? ''),
-        dateCtr: TextEditingController(text: data.date ?? ''),
+        dateCtr: DateEditingController(date: data.date ?? ''),
         urlCtr: TextEditingController(text: data.url ?? ''),
       );
 


### PR DESCRIPTION
- Migrates the remaining date fields listed below to store dates in the standard `yyyy-MM-dd` format.
  - Collection Events
    - Start Date
    - End Date
  - Narratives
    - Date
  - Specimens
    - Prep Date 
    - Collection Date
    - Capture Date
    - Specimen Part -> Date Taken
    - Associated Data -> Date
- Implements the `DateEditingController` in the associated date field widgets.
- Updates the `CommonDateField` to support the `DateEditingController` and to support retention of the set date when opening date pickers.
- Fixed a bug on collection events that was causing the clearing of End Date to clear Start Date instead.
