### PR TITLE
Standardize time fields

### DIFF
--- a/lib/screens/events/components/general_info.dart
+++ b/lib/screens/events/components/general_info.dart
@@ -339,7 +339,7 @@ class EventTimeField extends ConsumerWidget {
             CollEventServices(ref: ref).updateCollEvent(
               collEventId,
               CollEventCompanion(
-                startTime: db.Value(collEventCtr.startTimeCtr.text),
+                startTime: db.Value(collEventCtr.startTimeCtr.time),
               ),
             );
           },
@@ -361,7 +361,7 @@ class EventTimeField extends ConsumerWidget {
             CollEventServices(ref: ref).updateCollEvent(
               collEventId,
               CollEventCompanion(
-                endTime: db.Value(collEventCtr.endTimeCtr.text),
+                endTime: db.Value(collEventCtr.endTimeCtr.time),
               ),
             );
           },

--- a/lib/screens/shared/fields.dart
+++ b/lib/screens/shared/fields.dart
@@ -71,7 +71,7 @@ class CommonTimeField extends ConsumerStatefulWidget {
     required this.onClear,
   });
 
-  final TextEditingController controller;
+  final TimeEditingController controller;
   final String labelText;
   final String hintText;
   final TimeOfDay initialTime;
@@ -92,21 +92,21 @@ class CommonTimeFieldState extends ConsumerState<CommonTimeField> {
       ),
       controller: widget.controller,
       onTap: () async {
-        final time = await _showTimePicker(
+        final selectedTimeOfDate = await _showTimePicker(
           context: context,
           cancelText: "Clear",
-          initialTime: widget.initialTime,
+          initialTime: widget.controller.timeOfDay ?? widget.initialTime,
         );
 
         // OK pressed
-        if (time != null && mounted) {
-          widget.controller.text = _formatTimeOfDay(time);
+        if (selectedTimeOfDate != null && mounted) {
+          widget.controller.timeOfDay = selectedTimeOfDate;
           widget.onTap();
         }
 
         // Clear pressed (or picker closed)
-        if (time == null && mounted) {
-          widget.controller.text = "";
+        if (selectedTimeOfDate == null && mounted) {
+          widget.controller.timeOfDay = null;
           widget.onClear();
         }
       },

--- a/lib/screens/specimens/shared/capture_records.dart
+++ b/lib/screens/specimens/shared/capture_records.dart
@@ -618,7 +618,7 @@ class CaptureTimeState extends ConsumerState<CaptureTime> {
               SpecimenServices(ref: ref).updateSpecimen(
                 widget.specimenUuid,
                 SpecimenCompanion(
-                  captureTime: db.Value(widget.specimenCtr.captureTimeCtr.text),
+                  captureTime: db.Value(widget.specimenCtr.captureTimeCtr.time),
                 ),
               );
             },

--- a/lib/screens/specimens/shared/general_records.dart
+++ b/lib/screens/specimens/shared/general_records.dart
@@ -280,7 +280,7 @@ class SpecimenCollectionTimeField extends ConsumerWidget {
           specimenUuid,
           SpecimenCompanion(
               collectionTime: db.Value(
-            specimenCtr.collTimeCtr.text,
+            specimenCtr.collTimeCtr.time,
           )),
         );
       },
@@ -392,7 +392,7 @@ class PrepTimeField extends ConsumerWidget {
         SpecimenServices(ref: ref).updateSpecimen(
           specimenUuid,
           SpecimenCompanion(
-            prepTime: db.Value(specimenCtr.prepTimeCtr.text),
+            prepTime: db.Value(specimenCtr.prepTimeCtr.time),
           ),
         );
       },

--- a/lib/screens/specimens/shared/specimen_parts.dart
+++ b/lib/screens/specimens/shared/specimen_parts.dart
@@ -378,7 +378,7 @@ class PartSubTitle extends StatelessWidget {
       '$treatment'
       '${_getText(part.additionalTreatment)}'
       '${_getText(dateStdToDateDisplay(part.dateTaken))}'
-      '${_getText(part.timeTaken)}'
+      '${_getText(timeStdToTimeDisplay(part.timeTaken))}'
       '${_getPMI()}'
       '$remark',
       style: Theme.of(context).textTheme.bodyMedium,
@@ -593,7 +593,7 @@ class PartFormState extends ConsumerState<PartForm> {
       treatment: db.Value(widget.partCtr.treatmentCtr.text),
       additionalTreatment: db.Value(widget.partCtr.additionalTreatmentCtr.text),
       dateTaken: db.Value(widget.partCtr.dateTakenCtr.date),
-      timeTaken: db.Value(widget.partCtr.timeTakenCtr.text),
+      timeTaken: db.Value(widget.partCtr.timeTakenCtr.time),
       pmi: db.Value(widget.partCtr.pmiCtr.text),
       museumPermanent: db.Value(widget.partCtr.museumPermanentCtr.text),
       museumLoan: db.Value(widget.partCtr.museumLoanCtr.text),

--- a/lib/services/database/database.dart
+++ b/lib/services/database/database.dart
@@ -73,10 +73,10 @@ class Database extends _$Database {
     await m.addColumn(specimen, specimen.collectionDate);
 
     // Date and time format changes
-    await migrateProjectDatesFormat(m);
-    await migrateSpecimenDatesFormat(m);
-    await migrateNarrativeDatesFormat(m);
-    await migrateCollEventDatesFormat(m);
+    await migrateProjectDateTimeFormat(m);
+    await migrateSpecimenDateTimeFormat(m);
+    await migrateNarrativeDateTimeFormat(m);
+    await migrateCollEventDateTimeFormat(m);
   }
 
   Future<void> _migrateFromVersion4(Migrator m) async {

--- a/lib/services/database/migration_utilities.dart
+++ b/lib/services/database/migration_utilities.dart
@@ -28,7 +28,14 @@ String convertDateString(String inputDateString) {
   return DateFormat('yyyy-MM-dd').format(parsedDate);
 }
 
-Future<void> migrateProjectDatesFormat(Migrator m) async {
+String convertTimeString(String inputTimeString) {
+  DateTime? parsedTime = DateFormat('h:m a').tryParse(inputTimeString) ??
+      DateFormat('H:m').tryParse(inputTimeString);
+  if (parsedTime == null) return inputTimeString;
+  return DateFormat.Hms().format(parsedTime);
+}
+
+Future<void> migrateProjectDateTimeFormat(Migrator m) async {
   final db = m.database as Database;
 
   final fieldsToUpdate = ['startDate', 'endDate'];
@@ -59,10 +66,11 @@ Future<void> migrateProjectDatesFormat(Migrator m) async {
   }
 }
 
-Future<void> migrateSpecimenDatesFormat(Migrator m) async {
+Future<void> migrateSpecimenDateTimeFormat(Migrator m) async {
   final db = m.database as Database;
 
-  final specimenFieldsToUpdate = ['prepDate', 'collectionDate', 'captureDate'];
+  final specimenDateFields = ['prepDate', 'collectionDate', 'captureDate'];
+  final specimenTimeFields = ['prepTime', 'collectionTime', 'captureTime'];
   final projects = await ProjectQuery(db).getAllProjects();
 
   for (final projectData in projects) {
@@ -73,7 +81,7 @@ Future<void> migrateSpecimenDatesFormat(Migrator m) async {
       bool doSpecimenUpdate = false;
       final specimenJson = specimenData.toJson();
 
-      for (final field in specimenFieldsToUpdate) {
+      for (final field in specimenDateFields) {
         final dateString = specimenJson[field];
 
         if (dateString != null && dateString.isNotEmpty) {
@@ -82,6 +90,19 @@ Future<void> migrateSpecimenDatesFormat(Migrator m) async {
           if (updatedDateString != dateString) {
             doSpecimenUpdate = true;
             specimenJson[field] = updatedDateString;
+          }
+        }
+      }
+
+      for (final field in specimenTimeFields) {
+        final timeString = specimenJson[field];
+
+        if (timeString != null && timeString.isNotEmpty) {
+          final updatedTimeString = convertTimeString(timeString);
+
+          if (updatedTimeString != timeString) {
+            doSpecimenUpdate = true;
+            specimenJson[field] = updatedTimeString;
           }
         }
       }
@@ -97,20 +118,35 @@ Future<void> migrateSpecimenDatesFormat(Migrator m) async {
           await SpecimenPartQuery(db).getSpecimenParts(specimenData.uuid);
 
       for (final specimenPartData in specimenParts) {
+        bool doSpecimenPartUpdate = false;
         final specimenPartJson = specimenPartData.toJson();
-        final dateString = specimenPartJson['dateTaken'];
 
+        final dateString = specimenPartJson['dateTaken'];
         if (dateString != null && dateString.isNotEmpty) {
           final updatedDateString = convertDateString(dateString);
 
           if (updatedDateString != dateString) {
+            doSpecimenPartUpdate = true;
             specimenPartJson['dateTaken'] = updatedDateString;
-            final updatedSpecimenPartData =
-                SpecimenPartData.fromJson(specimenPartJson);
-            SpecimenPartQuery(db).updateSpecimenPart(
-                updatedSpecimenPartData.id as int,
-                updatedSpecimenPartData.toCompanion(false));
           }
+        }
+
+        final timeString = specimenPartJson['timeTaken'];
+        if (timeString != null && timeString.isNotEmpty) {
+          final updatedTimeString = convertTimeString(timeString);
+
+          if (updatedTimeString != timeString) {
+            doSpecimenPartUpdate = true;
+            specimenPartJson['timeTaken'] = updatedTimeString;
+          }
+        }
+
+        if (doSpecimenPartUpdate) {
+          final updatedSpecimenPartData =
+              SpecimenPartData.fromJson(specimenPartJson);
+          SpecimenPartQuery(db).updateSpecimenPart(
+              updatedSpecimenPartData.id as int,
+              updatedSpecimenPartData.toCompanion(false));
         }
       }
 
@@ -139,7 +175,7 @@ Future<void> migrateSpecimenDatesFormat(Migrator m) async {
   }
 }
 
-Future<void> migrateNarrativeDatesFormat(Migrator m) async {
+Future<void> migrateNarrativeDateTimeFormat(Migrator m) async {
   final db = m.database as Database;
   final projects = await ProjectQuery(db).getAllProjects();
 
@@ -165,11 +201,12 @@ Future<void> migrateNarrativeDatesFormat(Migrator m) async {
   }
 }
 
-Future<void> migrateCollEventDatesFormat(Migrator m) async {
+Future<void> migrateCollEventDateTimeFormat(Migrator m) async {
   final db = m.database as Database;
   final projects = await ProjectQuery(db).getAllProjects();
 
-  final collEventFieldsToUpdate = ['startDate', 'endDate'];
+  final collEventDateFields = ['startDate', 'endDate'];
+  final collEventTimeFields = ['startTime', 'endTime'];
 
   for (final projectData in projects) {
     final eventList =
@@ -179,7 +216,7 @@ Future<void> migrateCollEventDatesFormat(Migrator m) async {
       bool doUpdate = false;
       final eventJson = eventData.toJson();
 
-      for (final field in collEventFieldsToUpdate) {
+      for (final field in collEventDateFields) {
         final dateString = eventJson[field];
 
         if (dateString != null && dateString.isNotEmpty) {
@@ -188,6 +225,19 @@ Future<void> migrateCollEventDatesFormat(Migrator m) async {
           if (updatedDateString != dateString) {
             doUpdate = true;
             eventJson[field] = updatedDateString;
+          }
+        }
+      }
+
+      for (final field in collEventTimeFields) {
+        final timeString = eventJson[field];
+
+        if (timeString != null && timeString.isNotEmpty) {
+          final updatedTimeString = convertTimeString(timeString);
+
+          if (updatedTimeString != timeString) {
+            doUpdate = true;
+            eventJson[field] = updatedTimeString;
           }
         }
       }

--- a/lib/services/types/controllers.dart
+++ b/lib/services/types/controllers.dart
@@ -28,6 +28,31 @@ class DateEditingController extends TextEditingController {
   }
 }
 
+class TimeEditingController extends TextEditingController {
+  TimeOfDay? _timeOfDay;
+  String? _time;
+
+  TimeEditingController({String? time}) : 
+    _time = time,
+    _timeOfDay = timeStdToTimeOfDay(time),
+    super(text: timeStdToTimeDisplay(time));
+
+  String? get time => _time;    
+  TimeOfDay? get timeOfDay => _timeOfDay;
+
+  set timeOfDay(TimeOfDay? newTime) {
+    _timeOfDay = newTime;
+    _time = timeOfDayToTimeStd(newTime);
+    text = timeOfDayToTimeDisplay(_timeOfDay);
+  }
+
+  set time(String? newTime) {
+    _time = newTime;
+    _timeOfDay = timeStdToTimeOfDay(newTime);
+    text = timeOfDayToTimeDisplay(_timeOfDay);
+  }
+}
+
 class ProjectFormCtrModel {
   ProjectFormCtrModel({
     required this.projectNameCtr,

--- a/lib/services/types/controllers.dart
+++ b/lib/services/types/controllers.dart
@@ -202,8 +202,8 @@ class CollEventFormCtrModel {
   TextEditingController idSuffixCtr;
   DateEditingController startDateCtr;
   DateEditingController endDateCtr;
-  TextEditingController startTimeCtr;
-  TextEditingController endTimeCtr;
+  TimeEditingController startTimeCtr;
+  TimeEditingController endTimeCtr;
   String? primaryCollMethodCtr;
   TextEditingController noteCtr;
 
@@ -212,8 +212,8 @@ class CollEventFormCtrModel {
         idSuffixCtr: TextEditingController(),
         startDateCtr: DateEditingController(),
         endDateCtr: DateEditingController(),
-        startTimeCtr: TextEditingController(),
-        endTimeCtr: TextEditingController(),
+        startTimeCtr: TimeEditingController(),
+        endTimeCtr: TimeEditingController(),
         primaryCollMethodCtr: null,
         noteCtr: TextEditingController(),
       );
@@ -224,8 +224,8 @@ class CollEventFormCtrModel {
         idSuffixCtr: TextEditingController(text: collEvent.idSuffix),
         startDateCtr: DateEditingController(date: collEvent.startDate),
         endDateCtr: DateEditingController(date: collEvent.endDate),
-        startTimeCtr: TextEditingController(text: collEvent.startTime),
-        endTimeCtr: TextEditingController(text: collEvent.endTime),
+        startTimeCtr: TimeEditingController(time: collEvent.startTime),
+        endTimeCtr: TimeEditingController(time: collEvent.endTime),
         primaryCollMethodCtr: collEvent.primaryCollMethod,
         noteCtr: TextEditingController(text: collEvent.collMethodNotes),
       );
@@ -302,11 +302,11 @@ class SpecimenFormCtrModel {
   TextEditingController museumIDCtr;
   TextEditingController fieldNumberCtr;
   DateEditingController prepDateCtr;
-  TextEditingController prepTimeCtr;
+  TimeEditingController prepTimeCtr;
   DateEditingController collDateCtr;
-  TextEditingController collTimeCtr;
+  TimeEditingController collTimeCtr;
   DateEditingController captureDateCtr;
-  TextEditingController captureTimeCtr;
+  TimeEditingController captureTimeCtr;
   TextEditingController trapTypeCtr;
   TextEditingController methodIDCtr;
 
@@ -326,11 +326,11 @@ class SpecimenFormCtrModel {
         idMethodCtr: TextEditingController(),
         museumIDCtr: TextEditingController(),
         prepDateCtr: DateEditingController(),
-        prepTimeCtr: TextEditingController(),
+        prepTimeCtr: TimeEditingController(),
         collDateCtr: DateEditingController(),
-        collTimeCtr: TextEditingController(),
+        collTimeCtr: TimeEditingController(),
         captureDateCtr: DateEditingController(),
-        captureTimeCtr: TextEditingController(),
+        captureTimeCtr: TimeEditingController(),
         trapTypeCtr: TextEditingController(),
         methodIDCtr: TextEditingController(),
       );
@@ -353,11 +353,11 @@ class SpecimenFormCtrModel {
             TextEditingController(text: specimen.fieldNumber?.toString() ?? ''),
         speciesCtr: specimen.speciesID,
         prepDateCtr: DateEditingController(date: specimen.prepDate),
-        prepTimeCtr: TextEditingController(text: specimen.prepTime),
+        prepTimeCtr: TimeEditingController(time: specimen.prepTime),
         collDateCtr: DateEditingController(date: specimen.collectionDate),
-        collTimeCtr: TextEditingController(text: specimen.collectionTime),
+        collTimeCtr: TimeEditingController(time: specimen.collectionTime),
         captureDateCtr: DateEditingController(date: specimen.captureDate),
-        captureTimeCtr: TextEditingController(text: specimen.captureTime),
+        captureTimeCtr: TimeEditingController(time: specimen.captureTime),
         trapTypeCtr: TextEditingController(text: specimen.trapType),
         methodIDCtr: TextEditingController(text: specimen.methodID ?? ''),
         // ..selection =
@@ -743,7 +743,7 @@ class PartFormCtrModel {
   TextEditingController treatmentCtr;
   TextEditingController additionalTreatmentCtr;
   DateEditingController dateTakenCtr;
-  TextEditingController timeTakenCtr;
+  TimeEditingController timeTakenCtr;
   TextEditingController pmiCtr;
   TextEditingController museumPermanentCtr;
   TextEditingController museumLoanCtr;
@@ -758,7 +758,7 @@ class PartFormCtrModel {
         treatmentCtr: TextEditingController(),
         additionalTreatmentCtr: TextEditingController(),
         dateTakenCtr: DateEditingController(),
-        timeTakenCtr: TextEditingController(),
+        timeTakenCtr: TimeEditingController(),
         pmiCtr: TextEditingController(),
         museumPermanentCtr: TextEditingController(),
         museumLoanCtr: TextEditingController(),
@@ -775,7 +775,7 @@ class PartFormCtrModel {
         additionalTreatmentCtr:
             TextEditingController(text: data.additionalTreatment ?? ''),
         dateTakenCtr: DateEditingController(date: data.dateTaken ?? ''),
-        timeTakenCtr: TextEditingController(text: data.timeTaken ?? ''),
+        timeTakenCtr: TimeEditingController(time: data.timeTaken ?? ''),
         pmiCtr: TextEditingController(text: data.pmi ?? ''),
         museumPermanentCtr:
             TextEditingController(text: data.museumPermanent ?? ''),

--- a/lib/services/utility_services.dart
+++ b/lib/services/utility_services.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 String get listTileSeparator => " · ";
@@ -29,10 +30,32 @@ String getSystemDateTime() {
   return (date: formattedDate, time: formattedTime);
 }
 
+extension TimeOfDayFormatter on TimeOfDay {
+  String toTimeStd() {
+    final hour = this.hour.toString().padLeft(2,'0');
+    final minute = this.minute.toString().padLeft(2,'0');
+    final second = '00';
+    return '$hour:$minute:$second';
+  }
+
+  String toTimeDisplay() {
+    final hour = this.hourOfPeriod.toString();
+    final minute = this.minute.toString().padLeft(2,'0');
+    final amPM = this.period.name.toUpperCase();
+    return '$hour:$minute $amPM';
+  }
+}
+
 // Given a datetime, format it for display to the user (yMMMd)
 String dateTimeToDateDisplay(DateTime? inputDateTime) {
   if (inputDateTime == null) return '';
   return DateFormat.yMMMd().format(inputDateTime);
+}
+
+// Given a TimeOfDay, format it for display to the user (h:m a)
+String timeOfDayToTimeDisplay(TimeOfDay? inputTimeOfDay) {
+  if (inputTimeOfDay == null) return '';
+  return inputTimeOfDay.toTimeDisplay();
 }
 
 // Given a datetime, format it for storage (yyyy-MM-dd)
@@ -41,21 +64,28 @@ String dateTimeToDateStd(DateTime? inputDateTime) {
   return DateFormat('yyyy-MM-dd').format(inputDateTime);
 }
 
+// Given a TimeOfDay, format it for storage (h:m:s)
+String timeOfDayToTimeStd(TimeOfDay? inputTimeOfDay) {
+  if (inputTimeOfDay == null) return '';
+  return inputTimeOfDay.toTimeStd();
+}
+
 // Given a date string in the standard storage format (yyyy-MM-dd)
 // return a string in the standard display format (yMMMd)
 String? dateStdToDateDisplay(String? inputDateString) {
   if (inputDateString == null) return '';
-
   DateTime? parsedDate = DateFormat('yyyy-MM-dd').tryParse(inputDateString);
   if (parsedDate == null) return '';
-
   return DateFormat.yMMMd().format(parsedDate);
 }
 
-// Given a date string in the display format (yMMMd) return a DateTime
-DateTime? dateDisplayToDateTime(String? inputDateString) {
-  if (inputDateString == null) return null;
-  return DateFormat.yMMMd().tryParse(inputDateString);
+// Given a time string in the standard storage format (H:m:s)
+// return a string in the standard display format (h:m a), assuming a local timezone
+String? timeStdToTimeDisplay(String? inputTimeString) {
+  if (inputTimeString == null) return '';
+  DateTime? parsedTime = DateFormat.Hms().tryParse(inputTimeString);
+  if (parsedTime == null) return '';
+  return TimeOfDay.fromDateTime(parsedTime).toTimeDisplay();
 }
 
 // Given a date string in the standard format (yyyy-MM-dd) return a DateTime
@@ -64,15 +94,13 @@ DateTime? dateStdToDateTime(String? inputDateString) {
   return DateFormat('yyyy-MM-dd').tryParse(inputDateString);
 }
 
-// Given a displayed date string (yMMMd format), format it for DB storage (yyyy-MM-dd)
-String dateDisplayToDateStd(String? inputDateString) {
-  if (inputDateString == null) return '';
-
-  DateTime? parsedDate = DateFormat.yMMMd().tryParse(inputDateString);
-
-  if (parsedDate == null) return '';
-
-  return DateFormat('yyyy-MM-dd').format(parsedDate);
+// Given a time string in the standard storage format (H:m:s)
+// return a TimeOfDay, assuming a local timezone
+TimeOfDay? timeStdToTimeOfDay(String? inputTimeString) {
+  if (inputTimeString == null) return null;
+  DateTime? parsedTime = DateFormat.Hms().tryParse(inputTimeString);
+  if (parsedTime == null) return null;
+  return TimeOfDay.fromDateTime(parsedTime);
 }
 
 // Insert only unique values


### PR DESCRIPTION
- Migrates the time fields listed below to store times in the standard `HH:mm:ss` format.
  - Collection Events
    - Start Time
    - End Time
  - Specimens
    - Prep Time
    - Collection Time
    - Capture Time
    - Specimen Part -> Time Taken
- Implements a `TimeEditingController` to simplify time management in the associated time field widgets.
- Updates the `CommonTimeField` to support the `TimeEditingController` and to support retention of the set time when opening time pickers.