### PR TITLE
Fix specimen form data refresh issue after search

### DIFF
--- a/lib/screens/projects/taxonomy/specimen_list.dart
+++ b/lib/screens/projects/taxonomy/specimen_list.dart
@@ -17,9 +17,8 @@ import 'package:nahpu/services/utility_services.dart';
 class SpecimenListPage extends ConsumerStatefulWidget {
   const SpecimenListPage({
     super.key,
-    required this.specimenData,
   });
-  final List<SpecimenData> specimenData;
+
   @override
   SpecimenListPageState createState() => SpecimenListPageState();
 }
@@ -46,96 +45,100 @@ class SpecimenListPageState extends ConsumerState<SpecimenListPage> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Specimen Records'),
-      ),
-      body: SafeArea(
-          child: ScrollableConstrainedLayout(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            CommonSearchBar(
-              controller: _searchController,
-              focusNode: _focus,
-              hintText: 'Search specimens',
-              trailing: [
-                _searchController.text.isNotEmpty
-                    ? IconButton(
-                        onPressed: () {
-                          setState(() {
-                            _searchController.clear();
-                            ref.invalidate(specimenEntryProvider);
-                          });
-                        },
-                        icon: const Icon(Icons.clear_rounded))
-                    : const SizedBox.shrink(),
-                IconButton(
-                    onPressed: () {
+    return ref.watch(specimenEntryProvider).when(
+          data: (specimenData) => Scaffold(
+            appBar: AppBar(
+              title: const Text('Specimen Records'),
+            ),
+            body: SafeArea(
+                child: ScrollableConstrainedLayout(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  CommonSearchBar(
+                    controller: _searchController,
+                    focusNode: _focus,
+                    hintText: 'Search specimens',
+                    trailing: [
+                      _searchController.text.isNotEmpty
+                          ? IconButton(
+                              onPressed: () {
+                                setState(() {
+                                  _searchController.clear();
+                                  ref.invalidate(specimenEntryProvider);
+                                });
+                              },
+                              icon: const Icon(Icons.clear_rounded))
+                          : const SizedBox.shrink(),
+                      IconButton(
+                          onPressed: () {
+                            setState(() {
+                              _isSearchOptionVisible = !_isSearchOptionVisible;
+                            });
+                          },
+                          icon: const Icon(Icons.tune_rounded)),
+                    ],
+                    onChanged: (String query) async {
+                      _filteredSpecimenData = await SpecimenSearchServices(
+                        db: ref.read(databaseProvider),
+                        specimenEntries: specimenData,
+                        searchOption:
+                            SpecimenSearchOption.values[_selectedSearchValue],
+                      ).search(query.toLowerCase());
                       setState(() {
-                        _isSearchOptionVisible = !_isSearchOptionVisible;
+                        if (_searchController.text.isNotEmpty) {
+                          _isSearching = true;
+                        } else {
+                          _isSearching = false;
+                        }
                       });
                     },
-                    icon: const Icon(Icons.tune_rounded)),
-              ],
-              onChanged: (String query) async {
-                _filteredSpecimenData = await SpecimenSearchServices(
-                  db: ref.read(databaseProvider),
-                  specimenEntries: widget.specimenData,
-                  searchOption:
-                      SpecimenSearchOption.values[_selectedSearchValue],
-                ).search(query.toLowerCase());
-                setState(() {
-                  if (_searchController.text.isNotEmpty) {
-                    _isSearching = true;
-                  } else {
-                    _isSearching = false;
-                  }
-                });
-              },
-            ),
-            const SizedBox(height: 4),
-            Visibility(
-                visible: _isSearchOptionVisible,
-                child: SpecimenSearchChips(
-                  selectedValue: _selectedSearchValue,
-                  onSelected: (int index) {
-                    setState(() {
-                      _selectedSearchValue = index;
-                    });
-                  },
-                )),
-            const SizedBox(height: 8),
-            widget.specimenData.isEmpty
-                ? const Text('No specimens found')
-                : Column(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        specimenCount,
-                        style: Theme.of(context).textTheme.labelLarge,
-                      ),
-                      SpecimenList(
-                        data: _isSearching
-                            ? _filteredSpecimenData
-                            : widget.specimenData,
-                        additionalHeight: _isSearchOptionVisible ? 0 : 86,
-                      ),
-                    ],
                   ),
-          ],
-        ),
-      )),
-    );
+                  const SizedBox(height: 4),
+                  Visibility(
+                      visible: _isSearchOptionVisible,
+                      child: SpecimenSearchChips(
+                        selectedValue: _selectedSearchValue,
+                        onSelected: (int index) {
+                          setState(() {
+                            _selectedSearchValue = index;
+                          });
+                        },
+                      )),
+                  const SizedBox(height: 8),
+                  specimenData.isEmpty
+                      ? const Text('No specimens found')
+                      : Column(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              specimenCount(specimenData),
+                              style: Theme.of(context).textTheme.labelLarge,
+                            ),
+                            SpecimenList(
+                              data: _isSearching
+                                  ? _filteredSpecimenData
+                                  : specimenData,
+                              additionalHeight: _isSearchOptionVisible ? 0 : 86,
+                            ),
+                          ],
+                        ),
+                ],
+              ),
+            )),
+          ),
+          loading: () => const CommonProgressIndicator(),
+          error: (error, stack) => Text('Error: $error'),
+        );
   }
 
-  String get specimenCount {
+  String specimenCount(List<SpecimenData> data) {
     if (_isSearching) {
       int length = _filteredSpecimenData.length;
-      String specimenCount = widget.specimenData.length > 1
-          ? '${widget.specimenData.length} specimens'
-          : '${widget.specimenData.length} specimen';
+      String specimenCount = data.length > 1
+          ? '${data.length} specimens'
+          : '${data.length} specimen';
       if (length == 0) {
         return 'No specimens found';
       } else if (length == 1) {
@@ -144,7 +147,7 @@ class SpecimenListPageState extends ConsumerState<SpecimenListPage> {
         return 'Found: $length of $specimenCount';
       }
     } else {
-      return 'Specimen counts: ${widget.specimenData.length}';
+      return 'Specimen counts: ${data.length}';
     }
   }
 }
@@ -187,7 +190,7 @@ class SpecimenList extends StatelessWidget {
                     context,
                     MaterialPageRoute(
                         builder: (context) => SpecimenFormView(
-                              specimenData: data[index],
+                              specimenUuid: data[index].uuid,
                             )),
                   );
                 },

--- a/lib/screens/projects/taxonomy/taxon_registry.dart
+++ b/lib/screens/projects/taxonomy/taxon_registry.dart
@@ -10,7 +10,6 @@ import 'package:nahpu/screens/shared/forms.dart';
 import 'package:nahpu/screens/shared/common.dart';
 import 'package:nahpu/screens/projects/taxonomy/specimen_list.dart';
 import 'package:nahpu/services/database/database.dart';
-import 'package:nahpu/services/specimen_services.dart';
 import 'package:nahpu/services/statistics/captures.dart';
 
 class TaxonRegistryViewer extends ConsumerStatefulWidget {
@@ -228,15 +227,10 @@ class RecordedTaxaViewState extends ConsumerState<RecordedTaxaView> {
               ? const SizedBox.shrink()
               : TextButton(
                   onPressed: () async {
-                    final data =
-                        await SpecimenServices(ref: ref).getAllSpecimens();
                     if (context.mounted) {
                       Navigator.of(context).push(
                         MaterialPageRoute(
-                          builder: (context) => SpecimenListPage(
-                            specimenData: data,
-                          ),
-                        ),
+                            builder: (context) => SpecimenListPage()),
                       );
                     }
                   },

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -218,9 +218,9 @@ class SpecimenPages extends StatelessWidget {
 }
 
 class SpecimenFormView extends ConsumerStatefulWidget {
-  const SpecimenFormView({super.key, required this.specimenData});
+  const SpecimenFormView({super.key, required this.specimenUuid});
 
-  final SpecimenData specimenData;
+  final String specimenUuid;
 
   @override
   SpecimenFormViewState createState() => SpecimenFormViewState();
@@ -249,12 +249,13 @@ class SpecimenFormViewState extends ConsumerState<SpecimenFormView> {
                   if (specimenEntry.isEmpty) {
                     return const EmptySpecimen(isButtonVisible: false);
                   } else {
+                    final specimen = specimenEntry.firstWhere(
+                        (specimen) => specimen.uuid == widget.specimenUuid);
                     CatalogFmt catalogFmt =
-                        matchTaxonGroupToCatFmt(widget.specimenData.taxonGroup);
-                    final specimenFormCtr =
-                        _updateController(widget.specimenData);
+                        matchTaxonGroupToCatFmt(specimen.taxonGroup);
+                    final specimenFormCtr = _updateController(specimen);
                     return SpecimenForm(
-                      specimenUuid: widget.specimenData.uuid,
+                      specimenUuid: specimen.uuid,
                       specimenCtr: specimenFormCtr,
                       catalogFmt: catalogFmt,
                     );


### PR DESCRIPTION
Attempts a fix on #1.

* Removes the `getAllSpecimens()` call from `RecordedTaxaView`. This data can be retrieved from the `specimenEntryProvider` in the `SpecimenListPage` widget.
  * This fixes the issue of the unfiltered list not updating if the underlying selected specimen record is modified.
  * This does *not* fix the issue of a filtered list not updating if the underlying selected specimen record is modified.
* Changes the `SpecimenList` widget to pass a specimen UUID to the `SpecimenFormView` instead of passing specimen data directly. 
* Uses the `specimenEntryProvider` already setup in `SpecimenFormViewState` to access specimen data via the selected specimen UUID, rather than relying on specimen data directly.
  * This fixes the issue of the specimen record not refreshing on data change.
  * There's probably a better way to go about this, rather than searching the `specimenEntryProvider` provided list based on UUID, but I wanted to avoid modifying the provider.


https://github.com/user-attachments/assets/7e895a40-3211-403f-b8e2-7d163aee45e4

