### PR TITLE
Added check during data entry to alert users of negative head and body length

### DIFF
--- a/lib/screens/shared/fields.dart
+++ b/lib/screens/shared/fields.dart
@@ -242,6 +242,7 @@ class CommonNumField extends ConsumerWidget {
     required this.isLastField,
     this.isDouble = false,
     this.isSigned = false,
+    this.errorText,
   });
 
   final String labelText;
@@ -252,6 +253,7 @@ class CommonNumField extends ConsumerWidget {
   final bool isDouble;
   final bool enabled;
   final bool isSigned;
+  final String? errorText;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -261,10 +263,13 @@ class CommonNumField extends ConsumerWidget {
       decoration: InputDecoration(
         labelText: labelText,
         hintText: hintText,
+        errorText: errorText,
+        errorMaxLines: 3,
       ),
-      inputFormatters: isDouble
-          ? [FilteringTextInputFormatter.allow(RegExp(r"[0-9.-]"))]
-          : [FilteringTextInputFormatter.digitsOnly],
+      inputFormatters: [
+        FilteringTextInputFormatter.allow(
+            RegExp('${isSigned ? r'^-?' : ''}${r'\d*'}${isDouble ? r'\.?\d*' : ''}'))
+      ],
       keyboardType:
           TextInputType.numberWithOptions(decimal: isDouble, signed: isSigned),
       onChanged: onChanged,

--- a/lib/screens/specimens/mammalian/measurements.dart
+++ b/lib/screens/specimens/mammalian/measurements.dart
@@ -32,6 +32,7 @@ class MammalMeasurementFormsState
   MammalMeasurementCtrModel ctr = MammalMeasurementCtrModel.empty();
   TextEditingController headBodyLengthCtr = TextEditingController();
   TextEditingController tailHeadBodyPercentCtr = TextEditingController();
+  String? _hblErrorText;
 
   @override
   void initState() {
@@ -62,18 +63,17 @@ class MammalMeasurementFormsState
               hintText: 'Enter TTL',
               isLastField: false,
               isDouble: true,
+              errorText: _hblErrorText,
               onChanged: (String? value) {
-                if (value != null && value.isNotEmpty) {
                   setState(() {
                     _getHBTailPercent();
                     SpecimenServices(ref: ref).updateMammalMeasurement(
                       widget.specimenUuid,
                       MammalMeasurementCompanion(
-                        totalLength: db.Value(double.tryParse(value) ?? 0),
+                        totalLength: db.Value(double.tryParse(value ?? '') ?? 0),
                       ),
                     );
                   });
-                }
               },
             ),
             CommonNumField(
@@ -82,18 +82,17 @@ class MammalMeasurementFormsState
               hintText: 'Enter TL',
               isDouble: true,
               isLastField: false,
+              errorText: _hblErrorText,
               onChanged: (String? value) {
-                if (value != null && value.isNotEmpty) {
                   setState(() {
                     _getHBTailPercent();
                     SpecimenServices(ref: ref).updateMammalMeasurement(
                       widget.specimenUuid,
                       MammalMeasurementCompanion(
-                        tailLength: db.Value(double.tryParse(value)),
+                        tailLength: db.Value(double.tryParse(value ?? '') ?? 0),
                       ),
                     );
                   });
-                }
               },
             ),
           ],
@@ -361,11 +360,12 @@ class MammalMeasurementFormsState
       tailLengthText: ctr.tailLengthCtr.text,
     );
 
-    ({String headAndBodyText, String percentTailText})? results =
+    ({String headAndBodyText, String percentTailText, String errorText})? results =
         service.getHBandTailPercentage();
 
     headBodyLengthCtr.text = results?.headAndBodyText ?? '';
     tailHeadBodyPercentCtr.text = results?.percentTailText ?? '';
+    _hblErrorText = results?.errorText ?? '';
   }
 }
 

--- a/lib/services/specimen_services.dart
+++ b/lib/services/specimen_services.dart
@@ -690,15 +690,23 @@ class MammalMeasurementServices {
   final String totalLengthText;
   final String tailLengthText;
 
-  ({String headAndBodyText, String percentTailText})? getHBandTailPercentage() {
+  ({String headAndBodyText, String percentTailText, String errorText})? getHBandTailPercentage() {
     double? totalLength =
         totalLengthText.isNotEmpty ? double.tryParse(totalLengthText) : null;
     double? tailLength =
         tailLengthText.isNotEmpty ? double.tryParse(tailLengthText) : null;
     if (totalLength == null || tailLength == null || totalLength < 1) {
       return null;
+    } 
+    
+    double? headBodyLength = totalLength - tailLength;
+    if (headBodyLength <= 0) {
+      return (
+        headAndBodyText: '',
+        percentTailText: '',
+        errorText: 'Total length should not be less than or equal to tail length.',
+      );
     } else {
-      double headBodyLength = (totalLength - tailLength);
       String headAndBodyText = headBodyLength.truncateZeroFixed(1);
       String tailHeadBodyPercent =
           (tailLength / headBodyLength * 100).truncateZeroFixed(1);
@@ -706,7 +714,8 @@ class MammalMeasurementServices {
 
       return (
         headAndBodyText: headAndBodyText,
-        percentTailText: percentTailText
+        percentTailText: percentTailText,
+        errorText: '',
       );
     }
   }


### PR DESCRIPTION
I made a few small changes to stop the 'Head and body length (mm)' and 'Tail/HB length' fields from displaying negative values because someone accidentally set Tail length greater than Total length. The incorrect Tail length and Total length values still get persisted though, but this does give users a warning. I'll be able to take care of automatically finding outlier specimens in the next PR.

Here's a list of changes:

- For `fields.CommonNumField`: Added an error message field and updated the inputformatter's regex to take both isSigned and isDouble into account when formatting inputted numbers. If the number is signed, we will allow negative values, if not, we only allow positive values.
- Updated `MammalMeasurementServices.getHBandTailPercentage()` to also return error text 
- Updated `_getHBTailPercent` to fill in error text based on the results of  `MammalMeasurementServices.getHBandTailPercentage()`. Also removed validation forcing the Total and Tail length values to be non-null since it could prevent people from deleting values completely.


https://github.com/user-attachments/assets/feb7076d-565a-431f-b07d-3277222bce65

