### PR TITLE
Fixed bug with museum id being entered backwards

### DIFF
--- a/lib/screens/specimens/shared/general_records.dart
+++ b/lib/screens/specimens/shared/general_records.dart
@@ -562,7 +562,7 @@ class IdTile extends ConsumerWidget {
                 isLastField: true,
                 onChanged: (String? value) {
                   if (value != null) {
-                    SpecimenServices(ref: ref).updateSpecimen(
+                    SpecimenServices(ref: ref).updateSpecimenSkipInvalidation(
                       specimenUuid,
                       SpecimenCompanion(
                         museumID: db.Value(value),


### PR DESCRIPTION
There's an issue where the cursor resets to the left side of the Museum ID text field after each character is entered, reversing the order of typed letters as seen in https://github.com/nahpu/nahpu/issues/65.

Apparently, this was caused by some propagating callbacks being triggered that forced the UI to rebuild every time, was able to fix this by not refreshing UI every time
https://github.com/user-attachments/assets/ac36ae4f-c1e6-4227-a1c0-b0c1773c9d56

