### PR TITLE
Add Time field on Narratives form

### DIFF
--- a/lib/screens/narrative/components/top_forms.dart
+++ b/lib/screens/narrative/components/top_forms.dart
@@ -58,17 +58,74 @@ class DateForm extends ConsumerWidget {
       lastDate: DateTime.now(),
       controller: narrativeCtr.dateCtr,
       onTap: () {
+        // If time is set, combine date and time into a single datetime string
+        String? dateStd = narrativeCtr.dateCtr.date;
+        String? timeStd = narrativeCtr.timeCtr.time;
+        String? combined;
+        if (dateStd != null && dateStd.isNotEmpty && timeStd != null && timeStd.isNotEmpty) {
+          combined = '\$dateStd \$timeStd';
+        } else {
+          combined = dateStd;
+        }
         NarrativeServices(ref: ref).updateNarrative(
           narrativeId,
-          NarrativeCompanion(date: db.Value(narrativeCtr.dateCtr.date)),
+          NarrativeCompanion(date: db.Value(combined)),
         );
       },
       onClear: () {
+        // Clearing date should remove the stored date (and time)
+        narrativeCtr.timeCtr.time = null;
         NarrativeServices(ref: ref).updateNarrative(
           narrativeId,
           NarrativeCompanion(date: db.Value(null)),
         );
       }
+    );
+  }
+}
+
+class TimeForm extends ConsumerWidget {
+  const TimeForm({
+    super.key,
+    required this.narrativeId,
+    required this.narrativeCtr,
+  });
+
+  final int narrativeId;
+  final NarrativeFormCtrModel narrativeCtr;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return CommonTimeField(
+      labelText: 'Time',
+      hintText: 'Enter time',
+      initialTime: TimeOfDay.now(),
+      controller: narrativeCtr.timeCtr,
+      onTap: () {
+        // Combine with date if available
+        String? dateStd = narrativeCtr.dateCtr.date;
+        String? timeStd = narrativeCtr.timeCtr.time;
+        String? combined;
+        if (dateStd != null && dateStd.isNotEmpty && timeStd != null && timeStd.isNotEmpty) {
+          combined = '$dateStd $timeStd';
+        } else if (timeStd != null && timeStd.isNotEmpty) {
+          // If only time set, store as today with time
+          final today = DateTime.now();
+          final dateOnly = '${today.year.toString().padLeft(4, '0')}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
+          combined = '$dateOnly $timeStd';
+        }
+        NarrativeServices(ref: ref).updateNarrative(
+          narrativeId,
+          NarrativeCompanion(date: db.Value(combined)),
+        );
+      },
+      onClear: () {
+        // Clearing time keeps date only
+        NarrativeServices(ref: ref).updateNarrative(
+          narrativeId,
+          NarrativeCompanion(date: db.Value(narrativeCtr.dateCtr.date)),
+        );
+      },
     );
   }
 }

--- a/lib/screens/narrative/components/top_forms.dart
+++ b/lib/screens/narrative/components/top_forms.dart
@@ -58,18 +58,15 @@ class DateForm extends ConsumerWidget {
       lastDate: DateTime.now(),
       controller: narrativeCtr.dateCtr,
       onTap: () {
-        // If time is set, combine date and time into a single datetime string
+        // Persist date and (optionally) time into separate columns.
         String? dateStd = narrativeCtr.dateCtr.date;
         String? timeStd = narrativeCtr.timeCtr.time;
-        String? combined;
-        if (dateStd != null && dateStd.isNotEmpty && timeStd != null && timeStd.isNotEmpty) {
-          combined = '\$dateStd \$timeStd';
-        } else {
-          combined = dateStd;
-        }
         NarrativeServices(ref: ref).updateNarrative(
           narrativeId,
-          NarrativeCompanion(date: db.Value(combined)),
+          NarrativeCompanion(
+            date: db.Value(dateStd),
+            time: db.Value(timeStd),
+          ),
         );
       },
       onClear: () {
@@ -77,7 +74,7 @@ class DateForm extends ConsumerWidget {
         narrativeCtr.timeCtr.time = null;
         NarrativeServices(ref: ref).updateNarrative(
           narrativeId,
-          NarrativeCompanion(date: db.Value(null)),
+          NarrativeCompanion(date: db.Value(null), time: db.Value(null)),
         );
       }
     );
@@ -96,34 +93,41 @@ class TimeForm extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    void persistTimeChange(String? timeStd) {
+      String? dateStd = narrativeCtr.dateCtr.date;
+      
+      // If setting a time and no date is set, default to today
+      if (timeStd != null && timeStd.isNotEmpty && (dateStd == null || dateStd.isEmpty)) {
+        final today = DateTime.now();
+        dateStd = '${today.year.toString().padLeft(4, '0')}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
+        // Update both date and time
+        NarrativeServices(ref: ref).updateNarrative(
+          narrativeId,
+          NarrativeCompanion(
+            date: db.Value(dateStd),
+            time: db.Value(timeStd),
+          ),
+        );
+      } else {
+        // Just update time
+        NarrativeServices(ref: ref).updateNarrative(
+          narrativeId,
+          NarrativeCompanion(time: db.Value(timeStd)),
+        );
+      }
+    }
+
     return CommonTimeField(
       labelText: 'Time',
       hintText: 'Enter time',
       initialTime: TimeOfDay.now(),
       controller: narrativeCtr.timeCtr,
-      onTap: () {
-        // Combine with date if available
-        String? dateStd = narrativeCtr.dateCtr.date;
-        String? timeStd = narrativeCtr.timeCtr.time;
-        String? combined;
-        if (dateStd != null && dateStd.isNotEmpty && timeStd != null && timeStd.isNotEmpty) {
-          combined = '$dateStd $timeStd';
-        } else if (timeStd != null && timeStd.isNotEmpty) {
-          // If only time set, store as today with time
-          final today = DateTime.now();
-          final dateOnly = '${today.year.toString().padLeft(4, '0')}-${today.month.toString().padLeft(2, '0')}-${today.day.toString().padLeft(2, '0')}';
-          combined = '$dateOnly $timeStd';
-        }
-        NarrativeServices(ref: ref).updateNarrative(
-          narrativeId,
-          NarrativeCompanion(date: db.Value(combined)),
-        );
-      },
+      onTap: () => persistTimeChange(narrativeCtr.timeCtr.time),
       onClear: () {
         // Clearing time keeps date only
         NarrativeServices(ref: ref).updateNarrative(
           narrativeId,
-          NarrativeCompanion(date: db.Value(narrativeCtr.dateCtr.date)),
+          NarrativeCompanion(time: db.Value(null)),
         );
       },
     );

--- a/lib/screens/narrative/narrative_form.dart
+++ b/lib/screens/narrative/narrative_form.dart
@@ -46,20 +46,35 @@ class NarrativeFormState extends ConsumerState<NarrativeForm> {
             FormCard(
               isPrimary: true,
               isWithTitle: false,
-              child: AdaptiveLayout(
-                useHorizontalLayout: useHorizontalLayout,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
                 children: [
-                  DateForm(
-                    narrativeId: widget.narrativeId,
-                    narrativeCtr: widget.narrativeCtr,
+                  AdaptiveLayout(
+                    useHorizontalLayout: useHorizontalLayout,
+                    children: [
+                      DateForm(
+                        narrativeId: widget.narrativeId,
+                        narrativeCtr: widget.narrativeCtr,
+                      ),
+                      // Time field to the right of Date
+                      TimeForm(
+                        narrativeId: widget.narrativeId,
+                        narrativeCtr: widget.narrativeCtr,
+                      ),
+                    ],
                   ),
-                  SiteForm(
-                    narrativeId: widget.narrativeId,
-                    narrativeCtr: widget.narrativeCtr,
-                  ),
-                  WriterForm(
-                    narrativeId: widget.narrativeId,
-                    narrativeCtr: widget.narrativeCtr,
+                  AdaptiveLayout(
+                    useHorizontalLayout: useHorizontalLayout,
+                    children: [
+                      SiteForm(
+                        narrativeId: widget.narrativeId,
+                        narrativeCtr: widget.narrativeCtr,
+                      ),
+                      WriterForm(
+                        narrativeId: widget.narrativeId,
+                        narrativeCtr: widget.narrativeCtr,
+                      ),
+                    ],
                   ),
                 ],
               ),

--- a/lib/screens/narrative/narrative_form.dart
+++ b/lib/screens/narrative/narrative_form.dart
@@ -32,6 +32,23 @@ class NarrativeFormState extends ConsumerState<NarrativeForm> {
 
   @override
   void dispose() {
+    // Persist date and time (if any) before disposing controllers so that
+    // unsaved changes are not lost when the user navigates away.
+    try {
+      String? dateStd = widget.narrativeCtr.dateCtr.date;
+      String? timeStd = widget.narrativeCtr.timeCtr.time;
+
+      NarrativeServices(ref: ref).updateNarrative(
+        widget.narrativeId,
+        NarrativeCompanion(
+          date: db.Value(dateStd),
+          time: db.Value(timeStd),
+        ),
+      );
+    } catch (e) {
+      // Best-effort: don't crash on dispose if update fails.
+    }
+
     widget.narrativeCtr.dispose();
     super.dispose();
   }

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -199,13 +199,13 @@ class NarrativePages extends StatelessWidget {
 
   NarrativeFormCtrModel _updateController(
       List<NarrativeData> narrativeEntries, int index) {
-    // Try to extract time component from the stored date string. If the
-    // stored date contains a time (ISO datetime), create a time string in
-    // HH:mm:ss for the TimeEditingController. Otherwise leave it null.
-    String? storedDate = narrativeEntries[index].date;
-    String? timeStd;
-    if (storedDate != null) {
-      DateTime? parsed = DateTime.tryParse(storedDate);
+    // Prefer the separate `time` column if present; otherwise try
+    // to parse a time from the existing date string for backwards
+    // compatibility with old data.
+    String? timeStd = narrativeEntries[index].time;
+    if ((timeStd == null || timeStd.isEmpty) && narrativeEntries[index].date != null) {
+      final storedDate = narrativeEntries[index].date!;
+      final parsed = DateTime.tryParse(storedDate);
       if (parsed != null) {
         final hh = parsed.hour.toString().padLeft(2, '0');
         final mm = parsed.minute.toString().padLeft(2, '0');

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -199,8 +199,24 @@ class NarrativePages extends StatelessWidget {
 
   NarrativeFormCtrModel _updateController(
       List<NarrativeData> narrativeEntries, int index) {
+    // Try to extract time component from the stored date string. If the
+    // stored date contains a time (ISO datetime), create a time string in
+    // HH:mm:ss for the TimeEditingController. Otherwise leave it null.
+    String? storedDate = narrativeEntries[index].date;
+    String? timeStd;
+    if (storedDate != null) {
+      DateTime? parsed = DateTime.tryParse(storedDate);
+      if (parsed != null) {
+        final hh = parsed.hour.toString().padLeft(2, '0');
+        final mm = parsed.minute.toString().padLeft(2, '0');
+        final ss = parsed.second.toString().padLeft(2, '0');
+        timeStd = '$hh:$mm:$ss';
+      }
+    }
+
     return NarrativeFormCtrModel(
       dateCtr: DateEditingController(date: narrativeEntries[index].date),
+      timeCtr: TimeEditingController(time: timeStd),
       siteCtr: narrativeEntries[index].siteID,
       writerCtr: narrativeEntries[index].writerId,
       narrativeCtr:

--- a/lib/screens/shared/fields.dart
+++ b/lib/screens/shared/fields.dart
@@ -90,6 +90,25 @@ class CommonTimeField extends ConsumerStatefulWidget {
 
 class CommonTimeFieldState extends ConsumerState<CommonTimeField> {
   @override
+  void initState() {
+    super.initState();
+    widget.controller.addListener(_onTimeChanged);
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(_onTimeChanged);
+    super.dispose();
+  }
+
+  void _onTimeChanged() {
+    // Call onTap whenever the time value changes
+    if (widget.controller.time != null) {
+      widget.onTap();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return TextField(
       decoration: InputDecoration(

--- a/lib/services/database/database.dart
+++ b/lib/services/database/database.dart
@@ -79,9 +79,18 @@ class Database extends _$Database {
     } catch (e) {
       // ignore failures during migration; some older DBs may not need this
       if (kDebugMode) {
-        print('Migration v6: failed to add narrative.writerId: $e');
+        print('Migration v7: failed to add narrative.writerId: $e');
       }
     }
+    // Add time column to narrative table. Best-effort: ignore if already present.
+    try {
+      await m.addColumn(narrative, narrative.time);
+    } catch (e) {
+      if (kDebugMode) {
+        print('Migration v7: failed to add narrative.time: $e');
+      }
+    }
+    
 
     // Timezones
     await m.addColumn(project, project.timeZone);

--- a/lib/services/database/database.g.dart
+++ b/lib/services/database/database.g.dart
@@ -4871,6 +4871,12 @@ class Narrative extends Table with TableInfo<Narrative, NarrativeData> {
       type: DriftSqlType.string,
       requiredDuringInsert: false,
       $customConstraints: '');
+  static const VerificationMeta _timeMeta = const VerificationMeta('time');
+  late final GeneratedColumn<String> time = GeneratedColumn<String>(
+      'time', aliasedName, true,
+      type: DriftSqlType.string,
+      requiredDuringInsert: false,
+      $customConstraints: '');
   static const VerificationMeta _siteIDMeta = const VerificationMeta('siteID');
   late final GeneratedColumn<int> siteID = GeneratedColumn<int>(
       'siteID', aliasedName, true,
@@ -4900,7 +4906,7 @@ class Narrative extends Table with TableInfo<Narrative, NarrativeData> {
       $customConstraints: 'REFERENCES media(primaryId)');
   @override
   List<GeneratedColumn> get $columns =>
-      [id, projectUuid, date, siteID, writerId, narrative, mediaID];
+      [id, projectUuid, date, time, siteID, writerId, narrative, mediaID];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -4923,6 +4929,10 @@ class Narrative extends Table with TableInfo<Narrative, NarrativeData> {
     if (data.containsKey('date')) {
       context.handle(
           _dateMeta, date.isAcceptableOrUnknown(data['date']!, _dateMeta));
+    }
+    if (data.containsKey('time')) {
+      context.handle(
+          _timeMeta, time.isAcceptableOrUnknown(data['time']!, _timeMeta));
     }
     if (data.containsKey('siteID')) {
       context.handle(_siteIDMeta,
@@ -4955,6 +4965,8 @@ class Narrative extends Table with TableInfo<Narrative, NarrativeData> {
           .read(DriftSqlType.string, data['${effectivePrefix}projectUuid']),
       date: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}date']),
+      time: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}time']),
       siteID: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}siteID']),
       writerId: attachedDatabase.typeMapping
@@ -4984,6 +4996,9 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
   final int id;
   final String? projectUuid;
   final String? date;
+  final String? time;
+
+  /// Add this new column
   final int? siteID;
   final String? writerId;
   final String? narrative;
@@ -4992,6 +5007,7 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
       {required this.id,
       this.projectUuid,
       this.date,
+      this.time,
       this.siteID,
       this.writerId,
       this.narrative,
@@ -5005,6 +5021,9 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
     }
     if (!nullToAbsent || date != null) {
       map['date'] = Variable<String>(date);
+    }
+    if (!nullToAbsent || time != null) {
+      map['time'] = Variable<String>(time);
     }
     if (!nullToAbsent || siteID != null) {
       map['siteID'] = Variable<int>(siteID);
@@ -5028,6 +5047,7 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
           ? const Value.absent()
           : Value(projectUuid),
       date: date == null && nullToAbsent ? const Value.absent() : Value(date),
+      time: time == null && nullToAbsent ? const Value.absent() : Value(time),
       siteID:
           siteID == null && nullToAbsent ? const Value.absent() : Value(siteID),
       writerId: writerId == null && nullToAbsent
@@ -5049,6 +5069,7 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
       id: serializer.fromJson<int>(json['id']),
       projectUuid: serializer.fromJson<String?>(json['projectUuid']),
       date: serializer.fromJson<String?>(json['date']),
+      time: serializer.fromJson<String?>(json['time']),
       siteID: serializer.fromJson<int?>(json['siteID']),
       writerId: serializer.fromJson<String?>(json['writerId']),
       narrative: serializer.fromJson<String?>(json['narrative']),
@@ -5062,6 +5083,7 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
       'id': serializer.toJson<int>(id),
       'projectUuid': serializer.toJson<String?>(projectUuid),
       'date': serializer.toJson<String?>(date),
+      'time': serializer.toJson<String?>(time),
       'siteID': serializer.toJson<int?>(siteID),
       'writerId': serializer.toJson<String?>(writerId),
       'narrative': serializer.toJson<String?>(narrative),
@@ -5073,6 +5095,7 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
           {int? id,
           Value<String?> projectUuid = const Value.absent(),
           Value<String?> date = const Value.absent(),
+          Value<String?> time = const Value.absent(),
           Value<int?> siteID = const Value.absent(),
           Value<String?> writerId = const Value.absent(),
           Value<String?> narrative = const Value.absent(),
@@ -5081,6 +5104,7 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
         id: id ?? this.id,
         projectUuid: projectUuid.present ? projectUuid.value : this.projectUuid,
         date: date.present ? date.value : this.date,
+        time: time.present ? time.value : this.time,
         siteID: siteID.present ? siteID.value : this.siteID,
         writerId: writerId.present ? writerId.value : this.writerId,
         narrative: narrative.present ? narrative.value : this.narrative,
@@ -5092,6 +5116,7 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
       projectUuid:
           data.projectUuid.present ? data.projectUuid.value : this.projectUuid,
       date: data.date.present ? data.date.value : this.date,
+      time: data.time.present ? data.time.value : this.time,
       siteID: data.siteID.present ? data.siteID.value : this.siteID,
       writerId: data.writerId.present ? data.writerId.value : this.writerId,
       narrative: data.narrative.present ? data.narrative.value : this.narrative,
@@ -5105,6 +5130,7 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
           ..write('id: $id, ')
           ..write('projectUuid: $projectUuid, ')
           ..write('date: $date, ')
+          ..write('time: $time, ')
           ..write('siteID: $siteID, ')
           ..write('writerId: $writerId, ')
           ..write('narrative: $narrative, ')
@@ -5114,8 +5140,8 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
   }
 
   @override
-  int get hashCode =>
-      Object.hash(id, projectUuid, date, siteID, writerId, narrative, mediaID);
+  int get hashCode => Object.hash(
+      id, projectUuid, date, time, siteID, writerId, narrative, mediaID);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -5123,6 +5149,7 @@ class NarrativeData extends DataClass implements Insertable<NarrativeData> {
           other.id == this.id &&
           other.projectUuid == this.projectUuid &&
           other.date == this.date &&
+          other.time == this.time &&
           other.siteID == this.siteID &&
           other.writerId == this.writerId &&
           other.narrative == this.narrative &&
@@ -5133,6 +5160,7 @@ class NarrativeCompanion extends UpdateCompanion<NarrativeData> {
   final Value<int> id;
   final Value<String?> projectUuid;
   final Value<String?> date;
+  final Value<String?> time;
   final Value<int?> siteID;
   final Value<String?> writerId;
   final Value<String?> narrative;
@@ -5141,6 +5169,7 @@ class NarrativeCompanion extends UpdateCompanion<NarrativeData> {
     this.id = const Value.absent(),
     this.projectUuid = const Value.absent(),
     this.date = const Value.absent(),
+    this.time = const Value.absent(),
     this.siteID = const Value.absent(),
     this.writerId = const Value.absent(),
     this.narrative = const Value.absent(),
@@ -5150,6 +5179,7 @@ class NarrativeCompanion extends UpdateCompanion<NarrativeData> {
     this.id = const Value.absent(),
     this.projectUuid = const Value.absent(),
     this.date = const Value.absent(),
+    this.time = const Value.absent(),
     this.siteID = const Value.absent(),
     this.writerId = const Value.absent(),
     this.narrative = const Value.absent(),
@@ -5159,6 +5189,7 @@ class NarrativeCompanion extends UpdateCompanion<NarrativeData> {
     Expression<int>? id,
     Expression<String>? projectUuid,
     Expression<String>? date,
+    Expression<String>? time,
     Expression<int>? siteID,
     Expression<String>? writerId,
     Expression<String>? narrative,
@@ -5168,6 +5199,7 @@ class NarrativeCompanion extends UpdateCompanion<NarrativeData> {
       if (id != null) 'id': id,
       if (projectUuid != null) 'projectUuid': projectUuid,
       if (date != null) 'date': date,
+      if (time != null) 'time': time,
       if (siteID != null) 'siteID': siteID,
       if (writerId != null) 'writerId': writerId,
       if (narrative != null) 'narrative': narrative,
@@ -5179,6 +5211,7 @@ class NarrativeCompanion extends UpdateCompanion<NarrativeData> {
       {Value<int>? id,
       Value<String?>? projectUuid,
       Value<String?>? date,
+      Value<String?>? time,
       Value<int?>? siteID,
       Value<String?>? writerId,
       Value<String?>? narrative,
@@ -5187,6 +5220,7 @@ class NarrativeCompanion extends UpdateCompanion<NarrativeData> {
       id: id ?? this.id,
       projectUuid: projectUuid ?? this.projectUuid,
       date: date ?? this.date,
+      time: time ?? this.time,
       siteID: siteID ?? this.siteID,
       writerId: writerId ?? this.writerId,
       narrative: narrative ?? this.narrative,
@@ -5205,6 +5239,9 @@ class NarrativeCompanion extends UpdateCompanion<NarrativeData> {
     }
     if (date.present) {
       map['date'] = Variable<String>(date.value);
+    }
+    if (time.present) {
+      map['time'] = Variable<String>(time.value);
     }
     if (siteID.present) {
       map['siteID'] = Variable<int>(siteID.value);
@@ -5227,6 +5264,7 @@ class NarrativeCompanion extends UpdateCompanion<NarrativeData> {
           ..write('id: $id, ')
           ..write('projectUuid: $projectUuid, ')
           ..write('date: $date, ')
+          ..write('time: $time, ')
           ..write('siteID: $siteID, ')
           ..write('writerId: $writerId, ')
           ..write('narrative: $narrative, ')
@@ -15017,6 +15055,7 @@ typedef $NarrativeCreateCompanionBuilder = NarrativeCompanion Function({
   Value<int> id,
   Value<String?> projectUuid,
   Value<String?> date,
+  Value<String?> time,
   Value<int?> siteID,
   Value<String?> writerId,
   Value<String?> narrative,
@@ -15026,6 +15065,7 @@ typedef $NarrativeUpdateCompanionBuilder = NarrativeCompanion Function({
   Value<int> id,
   Value<String?> projectUuid,
   Value<String?> date,
+  Value<String?> time,
   Value<int?> siteID,
   Value<String?> writerId,
   Value<String?> narrative,
@@ -15067,6 +15107,9 @@ class $NarrativeFilterComposer extends Composer<_$Database, Narrative> {
 
   ColumnFilters<String> get date => $composableBuilder(
       column: $table.date, builder: (column) => ColumnFilters(column));
+
+  ColumnFilters<String> get time => $composableBuilder(
+      column: $table.time, builder: (column) => ColumnFilters(column));
 
   ColumnFilters<int> get siteID => $composableBuilder(
       column: $table.siteID, builder: (column) => ColumnFilters(column));
@@ -15115,6 +15158,9 @@ class $NarrativeOrderingComposer extends Composer<_$Database, Narrative> {
   ColumnOrderings<String> get date => $composableBuilder(
       column: $table.date, builder: (column) => ColumnOrderings(column));
 
+  ColumnOrderings<String> get time => $composableBuilder(
+      column: $table.time, builder: (column) => ColumnOrderings(column));
+
   ColumnOrderings<int> get siteID => $composableBuilder(
       column: $table.siteID, builder: (column) => ColumnOrderings(column));
 
@@ -15161,6 +15207,9 @@ class $NarrativeAnnotationComposer extends Composer<_$Database, Narrative> {
 
   GeneratedColumn<String> get date =>
       $composableBuilder(column: $table.date, builder: (column) => column);
+
+  GeneratedColumn<String> get time =>
+      $composableBuilder(column: $table.time, builder: (column) => column);
 
   GeneratedColumn<int> get siteID =>
       $composableBuilder(column: $table.siteID, builder: (column) => column);
@@ -15218,6 +15267,7 @@ class $NarrativeTableManager extends RootTableManager<
             Value<int> id = const Value.absent(),
             Value<String?> projectUuid = const Value.absent(),
             Value<String?> date = const Value.absent(),
+            Value<String?> time = const Value.absent(),
             Value<int?> siteID = const Value.absent(),
             Value<String?> writerId = const Value.absent(),
             Value<String?> narrative = const Value.absent(),
@@ -15227,6 +15277,7 @@ class $NarrativeTableManager extends RootTableManager<
             id: id,
             projectUuid: projectUuid,
             date: date,
+            time: time,
             siteID: siteID,
             writerId: writerId,
             narrative: narrative,
@@ -15236,6 +15287,7 @@ class $NarrativeTableManager extends RootTableManager<
             Value<int> id = const Value.absent(),
             Value<String?> projectUuid = const Value.absent(),
             Value<String?> date = const Value.absent(),
+            Value<String?> time = const Value.absent(),
             Value<int?> siteID = const Value.absent(),
             Value<String?> writerId = const Value.absent(),
             Value<String?> narrative = const Value.absent(),
@@ -15245,6 +15297,7 @@ class $NarrativeTableManager extends RootTableManager<
             id: id,
             projectUuid: projectUuid,
             date: date,
+            time: time,
             siteID: siteID,
             writerId: writerId,
             narrative: narrative,

--- a/lib/services/database/tables.drift
+++ b/lib/services/database/tables.drift
@@ -113,6 +113,7 @@ CREATE TABLE narrative (
     id INT NOT NULL PRIMARY KEY AUTOINCREMENT,
     projectUuid TEXT,
     date TEXT,
+    time TEXT,  -- Add this new column
     siteID INT,
     writerId TEXT,
     narrative TEXT,

--- a/lib/services/narrative_services.dart
+++ b/lib/services/narrative_services.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'package:flutter/foundation.dart';
 
 import 'package:nahpu/services/providers/narrative.dart';
 import 'package:nahpu/services/database/database.dart';
@@ -30,8 +31,54 @@ class NarrativeServices extends AppServices {
     return await NarrativeQuery(dbAccess).getNarrativeById(narrativeId);
   }
 
-  void updateNarrative(int id, NarrativeCompanion entries) {
-    NarrativeQuery(dbAccess).updateNarrativeEntry(id, entries);
+  Future<void> updateNarrative(int id, NarrativeCompanion entries) async {
+    try {
+      await NarrativeQuery(dbAccess).updateNarrativeEntry(id, entries);
+    } catch (e) {
+      // Handle missing column errors for older DBs by attempting to add the
+      // column and retrying the update. Query the table info first to avoid
+      // duplicate ALTER TABLE attempts when multiple callers race.
+      final msg = e.toString();
+      if (msg.contains('no such column')) {
+        try {
+          // Check whether the 'time' column already exists to avoid duplicate
+          // ALTER TABLE statements from concurrent callers.
+          final List<db.QueryRow> rows =
+              await dbAccess.customSelect("PRAGMA table_info('narrative')").get();
+          bool hasTime = false;
+          for (final row in rows) {
+            try {
+              final colName = row.read<String>('name');
+              if (colName == 'time') {
+                hasTime = true;
+                break;
+              }
+            } catch (_) {
+              // ignore read failures for unexpected rows
+            }
+          }
+
+          if (!hasTime) {
+            await dbAccess.customStatement('ALTER TABLE narrative ADD COLUMN time TEXT');
+          }
+
+          await NarrativeQuery(dbAccess).updateNarrativeEntry(id, entries);
+        } catch (e2) {
+          // If this still fails (for example due to race conditions), log in
+          // debug builds but don't crash the app.
+          if (kDebugMode) {
+            print('Failed to add narrative.time column during update: $e2');
+          }
+        }
+      } else {
+        if (kDebugMode) {
+          print('Failed to update narrative entry: $e');
+        }
+      }
+    } finally {
+      // Refresh narrative provider so UI reflects persisted change
+      ref.invalidate(narrativeEntryProvider);
+    }
   }
 
   /// Update the writer for a narrative.

--- a/lib/services/types/controllers.dart
+++ b/lib/services/types/controllers.dart
@@ -249,23 +249,27 @@ class CollEventFormCtrModel {
 class NarrativeFormCtrModel {
   NarrativeFormCtrModel({
     required this.dateCtr,
+    required this.timeCtr,
     required this.siteCtr,
     required this.writerCtr,
     required this.narrativeCtr,
   });
   DateEditingController dateCtr;
+  TimeEditingController timeCtr;
   int? siteCtr;
   String? writerCtr;
   TextEditingController narrativeCtr;
 
   factory NarrativeFormCtrModel.empty() => NarrativeFormCtrModel(
-      dateCtr: DateEditingController(),
-      siteCtr: null,
-      writerCtr: null,
-      narrativeCtr: TextEditingController());
+    dateCtr: DateEditingController(),
+    timeCtr: TimeEditingController(),
+    siteCtr: null,
+    writerCtr: null,
+    narrativeCtr: TextEditingController());
 
   void dispose() {
     dateCtr.dispose();
+    timeCtr.dispose();
     narrativeCtr.dispose();
   }
 }


### PR DESCRIPTION
Files changed:
1. controllers.dart — add timeCtr to NarrativeFormCtrModel.
2. narrative_view.dart — initialize TimeEditingController for narratives when creating the controller model.
3. top_forms.dart — add TimeForm and update DateForm persistence behavior.
4. narrative_form.dart — change layout to Date+Time row and Site+Writer row.

Summary of changes:
1. Added a time controller to the narrative form model:
File: controllers.dart
Added TimeEditingController timeCtr to NarrativeFormCtrModel.
Updated factory empty() and dispose() accordingly.

2. Initialize the time controller when creating the narrative form controllers:
File: narrative_view.dart
When building NarrativeFormCtrModel we now parse any time component from the stored narrative.date (if present) and set timeCtr to HH:mm:ss.

3. Added a Time picker form and combined date+time persistence logic:
File: lib/screens/narrative/components/top_forms.dart
Added TimeForm which uses CommonTimeField.
Updated DateForm so that when date is set/cleared it will include the time (if set) when updating the persisted narrative.date field.
Both DateForm and TimeForm combine date and time into a single storage string (format: yyyy-MM-dd HH:mm:ss) when updating the narrative record.

4. Adjusted the Narrative form layout to place Time next to Date, and move Site ID + Writer to the next row:
File: lib/screens/narrative/narrative_form.dart
Replaced the single AdaptiveLayout containing three widgets with two AdaptiveLayout rows:
Row 1: DateForm, TimeForm
Row 2: SiteForm, WriterForm
This keeps the responsive behavior: in wide layouts the fields appear side-by-side (Date|Time and SiteID|Writer), and in narrow layouts they'll stack appropriately.


Why I combined date+time into the existing narrative.date field?
The current database schema stores narrative.date (no separate time column). To avoid adding a schema migration in this small UI change, I combined date + time into one stored datetime string (yyyy-MM-dd HH:mm:ss) which is consistent with other places in the code that use the same format (e.g., getSystemDateTime). This means the date column will now contain both date and time when a time is set, and the UI will extract the time when loading.


Notes on edge cases and behavior
If the stored narrative.date is a plain date (no time), time field will be empty.
When the user sets date and time, both are combined and persisted into narrative.date.
Clearing the date clears both date and time in storage.
Clearing time keeps the stored date portion intact (only time component removed).
I preserved existing APIs and used existing helper formatting (controllers and utility functions).


Next steps / optional follow-ups
If you prefer a separate time column in the database (instead of embedding time into narrative.date), I can:
 Update tables.drift, bump schema version and add a database migration to add the column and migrate existing values.
 Update queries and model classes to use the new column.

<img width="1249" height="354" alt="2 rows" src="https://github.com/user-attachments/assets/f3c6011b-e968-461a-9ebb-e9882abdaa78" />
<img width="1227" height="609" alt="time" src="https://github.com/user-attachments/assets/98ab5776-2bc5-49fd-9107-5629921f65dd" />