### PR TITLE
Replace experimental TableMigration calls

### DIFF
--- a/lib/services/database/database.dart
+++ b/lib/services/database/database.dart
@@ -9,8 +9,6 @@ import 'package:path/path.dart' as p;
 
 part 'database.g.dart';
 
-// ignore_for_file: experimental_member_use
-
 /// The database schema version.
 /// Steps to update the schema:
 /// 1. Write the new schema in the [tables.drift] file.
@@ -151,14 +149,13 @@ class Database extends _$Database {
     await m.addColumn(associatedData, associatedData.specimenUuid);
     await m.renameColumn(associatedData, 'secondaryId', associatedData.name);
     await m.renameColumn(associatedData, 'fileId', associatedData.url);
+
     // Remove secondaryIdRef
-    await m.alterTable(TableMigration(associatedData));
+    await alterTableHelper(m, associatedData);
 
     // Sites
-    await m.alterTable(TableMigration(coordinate));
-    await m.alterTable(TableMigration(coordinate, columnTransformer: {
-      coordinate.elevationInMeter: coordinate.elevationInMeter.cast<double>(),
-    }));
+    await alterTableHelper(m, coordinate);
+    await castColumnsIntToReal(m, coordinate, ['elevationInMeter']);
   }
 
   Future<void> _migrateFromVersion3(Migrator m) async {
@@ -179,10 +176,10 @@ class Database extends _$Database {
 
     await m.deleteTable('fileMetadata');
     await m.deleteTable('personnelPhoto');
-    // delete column from media table and personnel tables
 
-    await m.alterTable(TableMigration(personnel));
-    await m.alterTable(TableMigration(media));
+    // delete column from media table and personnel tables
+    await alterTableHelper(m, personnel);
+    await alterTableHelper(m, media);
   }
 
   Future<void> _migrateV3only(Migrator m) async {
@@ -207,7 +204,7 @@ class Database extends _$Database {
     await m.deleteTable('bird_measurement');
     await m.createTable(avianMeasurement);
 
-    castMammalType(m);
+    await castMammalType(m);
   }
 
   Future<void> exportInto(File file) async {

--- a/lib/services/database/migration_utilities.dart
+++ b/lib/services/database/migration_utilities.dart
@@ -6,22 +6,57 @@ import 'package:nahpu/services/database/specimen_queries.dart';
 import 'package:nahpu/services/database/narrative_queries.dart';
 import 'package:intl/intl.dart';
 
-// ignore_for_file: experimental_member_use
+Future<void> castColumnsIntToReal(
+    Migrator m, dynamic table, List<String> colsToCast) async {
+  final db = m.database as Database;
+
+  final List<String> columnNames =
+      table.$columns.map((column) => column.name).toList().cast<String>();
+
+  final columnNamesCasted = columnNames.map((column) {
+    return (colsToCast.contains(column)) ? 'CAST($column AS REAL)' : column;
+  }).toList();
+
+  await db.customStatement(
+      'ALTER TABLE ${table.actualTableName} RENAME TO tmp_${table.actualTableName}');
+  await m.createTable(table);
+  await db.customStatement('''
+        INSERT INTO ${table.actualTableName} (${columnNames.join(', ')})
+        SELECT ${columnNamesCasted.join(', ')} FROM tmp_${table.actualTableName}
+      ''');
+  await db.customStatement('DROP TABLE tmp_${table.actualTableName}');
+}
+
+// Primarily used to drop columns
+Future<void> alterTableHelper(Migrator m, dynamic table) async {
+  final db = m.database as Database;
+
+  final List<String> columnNames =
+      table.$columns.map((column) => column.name).toList().cast<String>();
+
+  await db.customStatement(
+      'ALTER TABLE ${table.actualTableName} RENAME TO tmp_${table.actualTableName}');
+  await m.createTable(table);
+  await db.customStatement('''
+        INSERT INTO ${table.actualTableName} (${columnNames.join(', ')})
+        SELECT ${columnNames.join(', ')} FROM tmp_${table.actualTableName}
+      ''');
+  await db.customStatement('DROP TABLE tmp_${table.actualTableName}');
+}
 
 Future<void> castMammalType(Migrator m) async {
   final mammalMeasurement = (m.database as Database).mammalMeasurement;
+  final columnsToUpdate = [
+    'totalLength',
+    'tailLength',
+    'hindFootLength',
+    'earLength',
+    'forearm',
+    'testisLength',
+    'testisWidth'
+  ];
 
-  await m.alterTable(TableMigration(mammalMeasurement, columnTransformer: {
-    mammalMeasurement.totalLength: mammalMeasurement.totalLength.cast<double>(),
-    mammalMeasurement.tailLength: mammalMeasurement.tailLength.cast<double>(),
-    mammalMeasurement.hindFootLength:
-        mammalMeasurement.hindFootLength.cast<double>(),
-    mammalMeasurement.earLength: mammalMeasurement.earLength.cast<double>(),
-    mammalMeasurement.forearm: mammalMeasurement.forearm.cast<double>(),
-    mammalMeasurement.testisLength:
-        mammalMeasurement.testisLength.cast<double>(),
-    mammalMeasurement.testisWidth: mammalMeasurement.testisWidth.cast<double>(),
-  }));
+  await castColumnsIntToReal(m, mammalMeasurement, columnsToUpdate);
 }
 
 String convertDateString(String inputDateString) {


### PR DESCRIPTION
Adds two helper functions that replace use of experimental `TableMigration`, following the convention outlined [here](https://github.com/simolus3/drift/issues/803#issuecomment-687060939).

Closes #90.