### PR TITLE
Fix dropdown issue on new project creation

### DIFF
--- a/lib/services/types/specimens.dart
+++ b/lib/services/types/specimens.dart
@@ -97,8 +97,7 @@ const List<String> idConfidenceList = [
 
 const List<String> taxonGroupList = [
   'Birds',
-  'General Mammals',
-  'Bats',
+  'Mammals',
   'Herpetofauna',
 ];
 
@@ -107,7 +106,6 @@ CatalogFmt matchTaxonGroupToCatFmt(String? taxonGroup) {
     case 'Birds':
       return CatalogFmt.birds;
     case 'General Mammals':
-      return CatalogFmt.mammals;
     case 'Mammals':
       return CatalogFmt.mammals;
     case 'Herpetofauna':
@@ -148,6 +146,7 @@ SpecimenRecordType matchTaxonGroupToRecordType(String taxonGroup) {
     case 'Birds':
       return SpecimenRecordType.birds;
     case 'General Mammals':
+    case 'Mammals':
       return SpecimenRecordType.generalMammals;
     case 'Bats':
       return SpecimenRecordType.bats;


### PR DESCRIPTION
After merging bats with general mammals in #79, a bug was introduced with new project creation. The Main Taxon Group dropdown was missing a value for the combined `Mammals` taxon group.