### PR TITLE
Add multi-delete app-wide

### DIFF
--- a/lib/screens/events/components/effort.dart
+++ b/lib/screens/events/components/effort.dart
@@ -61,7 +61,7 @@ class AddEffortButton extends StatelessWidget {
   }
 }
 
-class CollEffortList extends ConsumerWidget {
+class CollEffortList extends ConsumerStatefulWidget {
   const CollEffortList({
     super.key,
     required this.collEventId,
@@ -70,17 +70,47 @@ class CollEffortList extends ConsumerWidget {
   final int collEventId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final collEffort = ref.watch(collEffortByEventProvider(collEventId));
+  CollEffortListState createState() => CollEffortListState();
+}
+
+class CollEffortListState extends ConsumerState<CollEffortList> {
+  bool _isSelecting = false;
+  final List<int> _selectedCollEfforts = [];
+
+  @override
+  Widget build(BuildContext context) {
+    final collEffort = ref.watch(collEffortByEventProvider(widget.collEventId));
     ScrollController scrollController = ScrollController();
     return collEffort.when(
       data: (data) {
         return data.isEmpty
-            ? EmptyEffort(collEventId: collEventId)
+            ? EmptyEffort(collEventId: widget.collEventId)
             : Column(
                 mainAxisAlignment: MainAxisAlignment.start,
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  SelectItemsInterface(
+                      isSelecting: _isSelecting,
+                      onClearPressed: _selectedCollEfforts.isEmpty
+                          ? null
+                          : () {
+                              setState(() {
+                                _selectedCollEfforts.clear();
+                              });
+                            },
+                      onSelectAllPressed: () {
+                        setState(() {
+                          _selectedCollEfforts.clear();
+                          _selectedCollEfforts
+                              .addAll(data.map((e) => e.id).toList());
+                        });
+                      },
+                      onSelectPressed: () {
+                        setState(() {
+                          _isSelecting = !_isSelecting;
+                          _selectedCollEfforts.clear();
+                        });
+                      }),
                   Flexible(
                     child: CommonScrollbar(
                       scrollController: scrollController,
@@ -89,19 +119,75 @@ class CollEffortList extends ConsumerWidget {
                         controller: scrollController,
                         itemCount: data.length,
                         itemBuilder: (context, index) {
-                          return CollEffortTile(collEffort: data[index]);
+                          return CollEffortTile(
+                            collEffort: data[index],
+                            isSelecting: _isSelecting,
+                            selectedCollEfforts: _selectedCollEfforts,
+                            onChanged: (bool? value) {
+                              setState(() {
+                                if (value == true) {
+                                  _selectedCollEfforts.add(data[index].id);
+                                } else {
+                                  _selectedCollEfforts.remove(data[index].id);
+                                }
+                              });
+                            },
+                          );
                         },
                       ),
                     ),
                   ),
                   const SizedBox(height: 8),
-                  AddEffortButton(collEventId: collEventId),
+                  AddEffortButton(collEventId: widget.collEventId),
+                  const SizedBox(height: 8),
+                  _isSelecting
+                      ? DeleteItemsButton(
+                          selectedItems: _selectedCollEfforts,
+                          itemName: _selectedCollEfforts.length == 1
+                              ? 'effort'
+                              : 'efforts',
+                          onPressedFunction: () async {
+                            await _deleteCollEfforts();
+                            setState(() {
+                              _selectedCollEfforts.clear();
+                            });
+                          })
+                      : const SizedBox.shrink(),
                 ],
               );
       },
       loading: () => const CircularProgressIndicator(),
       error: (error, stack) => Text(error.toString()),
     );
+  }
+
+  Future<void> _deleteCollEfforts() async {
+    try {
+      await CollEventServices(ref: ref)
+          .deleteCollEffortFromList(_selectedCollEfforts);
+      ref.invalidate(collEffortByEventProvider);
+      setState(() {
+        _isSelecting = false;
+      });
+      if (context.mounted) {
+        _pop();
+      }
+    } catch (e) {
+      if (context.mounted) {
+        _showError(e.toString());
+      }
+    }
+  }
+
+  void _pop() {
+    Navigator.pop(context);
+  }
+
+  void _showError(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(message),
+      duration: const Duration(seconds: 10),
+    ));
   }
 }
 
@@ -188,9 +274,15 @@ class CollEffortTile extends StatelessWidget {
   const CollEffortTile({
     super.key,
     required this.collEffort,
+    required this.isSelecting,
+    required this.selectedCollEfforts,
+    required this.onChanged,
   });
 
   final CollEffortData collEffort;
+  final bool isSelecting;
+  final List<int> selectedCollEfforts;
+  final void Function(bool?) onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -200,10 +292,25 @@ class CollEffortTile extends StatelessWidget {
         count: collEffort.count,
       ),
       subtitle: Subtitle(data: collEffort),
-      trailing: CollEffortMenu(
-        collEventId: collEffort.eventID!,
-        collEffortId: collEffort.id,
-        collToolCtr: CollEffortCtrModel.fromData(collEffort),
+      leading: isSelecting
+          ? ListCheckBox(
+              isDisabled: false,
+              value: selectedCollEfforts.contains(collEffort.id),
+              onChanged: onChanged)
+          : const SizedBox.shrink(),
+      trailing: IconButton(
+        icon: const Icon(Icons.edit_outlined),
+        onPressed: () {
+          Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => EditCollEffort(
+                  collEffortId: collEffort.id,
+                  collEventId: collEffort.eventID!,
+                  collToolCtr: CollEffortCtrModel.fromData(collEffort),
+                ),
+              ));
+        },
       ),
     );
   }
@@ -260,76 +367,6 @@ class Subtitle extends StatelessWidget {
       return 'N/A';
     } else {
       return data.size!;
-    }
-  }
-}
-
-class CollEffortMenu extends ConsumerStatefulWidget {
-  const CollEffortMenu({
-    super.key,
-    required this.collEventId,
-    required this.collEffortId,
-    required this.collToolCtr,
-  });
-
-  final int collEventId;
-  final int collEffortId;
-  final CollEffortCtrModel collToolCtr;
-
-  @override
-  CollEffortMenuState createState() => CollEffortMenuState();
-}
-
-class CollEffortMenuState extends ConsumerState<CollEffortMenu> {
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<EffortPopUpMenuItems>(
-      icon: const Icon(Icons.more_vert),
-      onSelected: _onSelected,
-      itemBuilder: (context) => <PopupMenuEntry<EffortPopUpMenuItems>>[
-        const PopupMenuItem(
-          value: EffortPopUpMenuItems.edit,
-          child: ListTile(
-            leading: Icon(Icons.edit_outlined),
-            title: Text('Edit'),
-          ),
-        ),
-        const PopupMenuDivider(
-          height: 10,
-        ),
-        PopupMenuItem(
-          value: EffortPopUpMenuItems.delete,
-          child: ListTile(
-            leading: Icon(Icons.delete_outline,
-                color: Theme.of(context).colorScheme.error),
-            title: Text('Delete',
-                style: TextStyle(color: Theme.of(context).colorScheme.error)),
-          ),
-        ),
-      ],
-    );
-  }
-
-  void _onSelected(EffortPopUpMenuItems item) {
-    switch (item) {
-      case EffortPopUpMenuItems.edit:
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => EditCollEffort(
-              collEffortId: widget.collEffortId,
-              collEventId: widget.collEventId,
-              collToolCtr: widget.collToolCtr,
-            ),
-          ),
-        );
-        break;
-      case EffortPopUpMenuItems.delete:
-        CollEventServices(ref: ref).deleteCollEffort(
-          widget.collEffortId,
-        );
-        ref.invalidate(collEffortByEventProvider);
-        break;
     }
   }
 }

--- a/lib/screens/events/components/effort.dart
+++ b/lib/screens/events/components/effort.dart
@@ -296,20 +296,22 @@ class CollEffortTile extends StatelessWidget {
               value: selectedCollEfforts.contains(collEffort.id),
               onChanged: onChanged)
           : const SizedBox.shrink(),
-      trailing: IconButton(
-        icon: const Icon(Icons.edit_outlined),
-        onPressed: () {
-          Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => EditCollEffort(
-                  collEffortId: collEffort.id,
-                  collEventId: collEffort.eventID!,
-                  collToolCtr: CollEffortCtrModel.fromData(collEffort),
-                ),
-              ));
-        },
-      ),
+      trailing: !isSelecting
+          ? IconButton(
+              icon: const Icon(Icons.edit_outlined),
+              onPressed: () {
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => EditCollEffort(
+                        collEffortId: collEffort.id,
+                        collEventId: collEffort.eventID!,
+                        collToolCtr: CollEffortCtrModel.fromData(collEffort),
+                      ),
+                    ));
+              },
+            )
+          : SizedBox.shrink(),
     );
   }
 }

--- a/lib/screens/events/components/effort.dart
+++ b/lib/screens/events/components/effort.dart
@@ -138,10 +138,9 @@ class CollEffortListState extends ConsumerState<CollEffortList> {
                     ),
                   ),
                   const SizedBox(height: 8),
-                  AddEffortButton(collEventId: widget.collEventId),
-                  const SizedBox(height: 8),
-                  _isSelecting
-                      ? DeleteItemsButton(
+                  !_isSelecting
+                      ? AddEffortButton(collEventId: widget.collEventId)
+                      : DeleteItemsButton(
                           selectedItems: _selectedCollEfforts,
                           itemName: _selectedCollEfforts.length == 1
                               ? 'effort'
@@ -151,8 +150,7 @@ class CollEffortListState extends ConsumerState<CollEffortList> {
                             setState(() {
                               _selectedCollEfforts.clear();
                             });
-                          })
-                      : const SizedBox.shrink(),
+                          }),
                 ],
               );
       },

--- a/lib/screens/events/components/personnel.dart
+++ b/lib/screens/events/components/personnel.dart
@@ -109,12 +109,11 @@ class CollectingPersonnelFormState extends ConsumerState<EventPersonnel> {
                                   ),
                                 ),
                                 const SizedBox(height: 8),
-                                AddPersonnelButton(
-                                  onPressed: _addPersonnel,
-                                ),
-                                const SizedBox(height: 8),
-                                _isSelecting
-                                    ? DeleteItemsButton(
+                                !_isSelecting
+                                    ? AddPersonnelButton(
+                                        onPressed: _addPersonnel,
+                                      )
+                                    : DeleteItemsButton(
                                         selectedItems: _selectedCollPers,
                                         itemName: 'personnel',
                                         onPressedFunction: () async {
@@ -130,8 +129,7 @@ class CollectingPersonnelFormState extends ConsumerState<EventPersonnel> {
                                         customDialogText:
                                             'Are you sure you want to remove the selected personnel from this event?',
                                         customDialogButtonText: 'Remove',
-                                      )
-                                    : const SizedBox.shrink(),
+                                      ),
                               ],
                             );
                     },

--- a/lib/screens/events/components/personnel.dart
+++ b/lib/screens/events/components/personnel.dart
@@ -26,6 +26,9 @@ class EventPersonnel extends ConsumerStatefulWidget {
 
 class CollectingPersonnelFormState extends ConsumerState<EventPersonnel> {
   final ScrollController scrollController = ScrollController();
+  bool _isSelecting = false;
+  final List<int> _selectedCollPers = [];
+
   @override
   void initState() {
     super.initState();
@@ -51,6 +54,28 @@ class CollectingPersonnelFormState extends ConsumerState<EventPersonnel> {
                           ? EmptyPersonnel(onPressed: _addPersonnel)
                           : Column(
                               children: [
+                                SelectItemsInterface(
+                                    isSelecting: _isSelecting,
+                                    onClearPressed: _selectedCollPers.isEmpty
+                                        ? null
+                                        : () {
+                                            setState(() {
+                                              _selectedCollPers.clear();
+                                            });
+                                          },
+                                    onSelectAllPressed: () {
+                                      setState(() {
+                                        _selectedCollPers.clear();
+                                        _selectedCollPers.addAll(
+                                            data.map((e) => e.id).toList());
+                                      });
+                                    },
+                                    onSelectPressed: () {
+                                      setState(() {
+                                        _isSelecting = !_isSelecting;
+                                        _selectedCollPers.clear();
+                                      });
+                                    }),
                                 Flexible(
                                   child: CommonScrollbar(
                                     scrollController: scrollController,
@@ -61,6 +86,20 @@ class CollectingPersonnelFormState extends ConsumerState<EventPersonnel> {
                                           .map(
                                             (person) => EventPersonnelField(
                                               eventID: widget.eventID,
+                                              isSelecting: _isSelecting,
+                                              selectedCollPers:
+                                                  _selectedCollPers,
+                                              onChanged: (bool? value) {
+                                                setState(() {
+                                                  if (value == true) {
+                                                    _selectedCollPers
+                                                        .add(person.id);
+                                                  } else {
+                                                    _selectedCollPers
+                                                        .remove(person.id);
+                                                  }
+                                                });
+                                              },
                                               controller:
                                                   _addPersonnelCtr(person),
                                             ),
@@ -73,6 +112,26 @@ class CollectingPersonnelFormState extends ConsumerState<EventPersonnel> {
                                 AddPersonnelButton(
                                   onPressed: _addPersonnel,
                                 ),
+                                const SizedBox(height: 8),
+                                _isSelecting
+                                    ? DeleteItemsButton(
+                                        selectedItems: _selectedCollPers,
+                                        itemName: 'personnel',
+                                        onPressedFunction: () async {
+                                          await _deletePersonnel();
+                                          setState(() {
+                                            _selectedCollPers.clear();
+                                          });
+                                        },
+                                        customIconButtonText:
+                                            'Remove ${_selectedCollPers.length} personnel from event',
+                                        customDialogHeader:
+                                            'Remove event personnel',
+                                        customDialogText:
+                                            'Are you sure you want to remove the selected personnel from this event?',
+                                        customDialogButtonText: 'Remove',
+                                      )
+                                    : const SizedBox.shrink(),
                               ],
                             );
                     },
@@ -99,6 +158,35 @@ class CollectingPersonnelFormState extends ConsumerState<EventPersonnel> {
     final EventPersonnelCtrModel newPersonnel =
         EventPersonnelCtrModel.fromData(form);
     return newPersonnel;
+  }
+
+  Future<void> _deletePersonnel() async {
+    try {
+      await CollEventServices(ref: ref)
+          .deleteCollPersonnelFromList(_selectedCollPers);
+      ref.invalidate(collPersonnelProvider);
+      setState(() {
+        _isSelecting = false;
+      });
+      if (context.mounted) {
+        _pop();
+      }
+    } catch (e) {
+      if (context.mounted) {
+        _showError(e.toString());
+      }
+    }
+  }
+
+  void _pop() {
+    Navigator.pop(context);
+  }
+
+  void _showError(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(message),
+      duration: const Duration(seconds: 10),
+    ));
   }
 }
 
@@ -139,10 +227,16 @@ class EventPersonnelField extends ConsumerStatefulWidget {
   const EventPersonnelField({
     super.key,
     required this.eventID,
+    required this.isSelecting,
+    required this.selectedCollPers,
+    required this.onChanged,
     required this.controller,
   });
 
   final int eventID;
+  final bool isSelecting;
+  final List<int> selectedCollPers;
+  final void Function(bool?) onChanged;
   final EventPersonnelCtrModel controller;
 
   @override
@@ -155,6 +249,12 @@ class EventPersonnelFieldState extends ConsumerState<EventPersonnelField> {
     return CommonPadding(
         child: Row(
       children: [
+        widget.isSelecting
+            ? ListCheckBox(
+                isDisabled: false,
+                value: widget.selectedCollPers.contains(widget.controller.id!),
+                onChanged: widget.onChanged)
+            : const SizedBox.shrink(),
         Expanded(
           child: DropdownButtonFormField<String>(
             initialValue: widget.controller.nameIDCtr,
@@ -177,7 +277,6 @@ class EventPersonnelFieldState extends ConsumerState<EventPersonnelField> {
                 ),
             onChanged: (value) {
               widget.controller.nameIDCtr = value ?? '';
-
               CollEventServices(ref: ref).updateCollPersonnel(
                 widget.controller.id!,
                 CollPersonnelCompanion(
@@ -195,47 +294,8 @@ class EventPersonnelFieldState extends ConsumerState<EventPersonnelField> {
             controller: widget.controller,
           ),
         ),
-        IconButton(
-          icon: const Icon(Icons.delete_outline),
-          onPressed: () {
-            _deletePersonnel();
-          },
-        ),
       ],
     ));
-  }
-
-  void _deletePersonnel() {
-    showDeleteAlertOnMenu(
-      context: context,
-      title: 'Delete collecting personnel?',
-      deletePrompt: 'You will delete this personnel from the event',
-      onDelete: () async {
-        try {
-          await CollEventServices(ref: ref)
-              .deleteCollPersonnel(widget.controller.id!);
-          if (context.mounted) {
-            _pop();
-          }
-        } catch (e) {
-          if (context.mounted) {
-            _showError(e.toString());
-          }
-        }
-      },
-    );
-  }
-
-  void _showError(String errors) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(errors),
-      ),
-    );
-  }
-
-  void _pop() {
-    Navigator.pop(context);
   }
 }
 

--- a/lib/screens/projects/personnel/manage_personnel.dart
+++ b/lib/screens/projects/personnel/manage_personnel.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:nahpu/services/platform_services.dart';
 import 'package:nahpu/services/providers/personnel.dart';
 import 'package:nahpu/screens/projects/personnel/new_personnel.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
@@ -9,6 +8,7 @@ import 'package:nahpu/screens/shared/fields.dart';
 import 'package:nahpu/screens/shared/layout.dart';
 import 'package:nahpu/services/database/database.dart';
 import 'package:nahpu/services/personnel_services.dart';
+import 'package:nahpu/screens/projects/personnel/personnel.dart';
 
 class ManagePersonnel extends ConsumerStatefulWidget {
   const ManagePersonnel({super.key});
@@ -132,6 +132,7 @@ class PersonnelListView extends ConsumerStatefulWidget {
 class PersonnelListViewState extends ConsumerState<PersonnelListView> {
   final ScrollController _scrollController = ScrollController();
   final List<String> _selectedPersonnel = [];
+  List<String> _allPersonnel = [];
   List<String> _allowedPersonnel = [];
   List<String> _listedInProjectPersonnel = [];
   bool _isSelecting = false;
@@ -152,61 +153,30 @@ class PersonnelListViewState extends ConsumerState<PersonnelListView> {
     return Column(
       mainAxisSize: MainAxisSize.max,
       children: [
-        Row(
-          children: [
-            Visibility(
-              visible: _isSelecting,
-              child: TextButton(
-                onPressed: _selectedPersonnel.isEmpty
-                    ? null
-                    : () {
-                        setState(() {
-                          _selectedPersonnel.clear();
-                        });
-                      },
-                child: const Text('Clear'),
-              ),
-            ),
-            Visibility(
-              visible: _isSelecting,
-              child: TextButton(
-                onPressed: widget.personnelList.length ==
-                        _listedInProjectPersonnel.length
-                    // _selectedPersonnel.length == _allowedPersonnel.length
-                    ? null
-                    : () {
-                        setState(() {
-                          _selectedPersonnel.clear();
-                          _selectedPersonnel.addAll(_allowedPersonnel);
-                        });
-                      },
-                child: const Text('Select all'),
-              ),
-            ),
-            const Spacer(),
-            Visibility(
-              visible: _isSelecting,
-              child: TextButton(
-                onPressed: () async {
-                  await _showActionOptions();
+        SelectItemsInterface(
+          isSelecting: _isSelecting,
+          onClearPressed: _selectedPersonnel.isEmpty
+              ? null
+              : () {
+                  setState(() {
+                    _selectedPersonnel.clear();
+                  });
                 },
-                child: const Text('Actions'),
-              ),
-            ),
-            TextButton(
-              onPressed: () async {
-                _listedInProjectPersonnel =
-                    await _getListedPersonnelInProject();
-                _allowedPersonnel = _getAllowedPersonnel();
-
-                setState(() {
-                  _isSelecting = !_isSelecting;
-                  _selectedPersonnel.clear();
-                });
-              },
-              child: Text(_isSelecting ? 'Cancel' : 'Select'),
-            ),
-          ],
+          onSelectAllPressed: () {
+            setState(() {
+              _selectedPersonnel.clear();
+              _selectedPersonnel.addAll(_allPersonnel);
+            });
+          },
+          onSelectPressed: () async {
+            _listedInProjectPersonnel = await _getListedPersonnelInProject();
+            _allowedPersonnel = _getAllowedPersonnel();
+            _allPersonnel = _getAllPersonnel();
+            setState(() {
+              _isSelecting = !_isSelecting;
+              _selectedPersonnel.clear();
+            });
+          },
         ),
         Expanded(
             child: CommonScrollbar(
@@ -234,126 +204,52 @@ class PersonnelListViewState extends ConsumerState<PersonnelListView> {
                         },
                       );
                     }))),
+        const SizedBox(height: 8),
+        _isSelecting
+            ? DeleteItemsButton(
+                selectedItems: _selectedPersonnel,
+                itemName: 'personnel',
+                onPressedFunction: () async {
+                  await _deletePersonnel();
+                  setState(() {
+                    _selectedPersonnel.clear();
+                  });
+                })
+            : const SizedBox.shrink(),
       ],
     );
   }
 
-  Future<void> _showActionOptions() async {
-    if (systemPlatform == PlatformType.mobile) {
-      await showModalBottomSheet(
-          context: context,
-          showDragHandle: true,
-          builder: (context) {
-            return Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 8),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ListTile(
-                    leading: Icon(
-                      Icons.delete_outlined,
-                      color: Theme.of(context).colorScheme.error,
-                    ),
-                    title: Text('Delete personnel',
-                        style: TextStyle(
-                            color: Theme.of(context).colorScheme.error)),
-                    onTap: widget.personnelList.length ==
-                            _listedInProjectPersonnel.length
-                        ? null
-                        : () {
-                            Navigator.pop(context);
-                            showDialog(
-                                context: context,
-                                builder: (context) {
-                                  return AlertDialog(
-                                    title: const Text('Delete personnel'),
-                                    content: const Text(
-                                        'Are you sure you want to delete the selected personnel?'),
-                                    actions: [
-                                      TextButton(
-                                        onPressed: () {
-                                          Navigator.of(context).pop();
-                                        },
-                                        child: const Text('Cancel'),
-                                      ),
-                                      TextButton(
-                                        onPressed: () async {
-                                          await _deletePersonnel();
-                                        },
-                                        child: const Text('Delete'),
-                                      ),
-                                    ],
-                                  );
-                                });
-                          },
-                  ),
-                ],
-              ),
-            );
-          });
-    } else {
-      await showDialog(
-          context: context,
-          builder: (context) {
-            return AlertDialog(
-              title: const Text('Actions'),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  ListTile(
-                    title: const Text('Delete personnel'),
-                    onTap: widget.personnelList.length ==
-                            _listedInProjectPersonnel.length
-                        ? null
-                        : () {
-                            Navigator.pop(context);
-                            showDialog(
-                                context: context,
-                                builder: (context) {
-                                  return AlertDialog(
-                                    title: const Text('Delete personnel'),
-                                    content: const Text(
-                                        'Are you sure you want to delete the selected personnel?'),
-                                    actions: [
-                                      TextButton(
-                                        onPressed: () {
-                                          Navigator.of(context).pop();
-                                        },
-                                        child: const Text('Cancel'),
-                                      ),
-                                      TextButton(
-                                        onPressed: () async {
-                                          await _deletePersonnel();
-                                        },
-                                        child: const Text('Delete'),
-                                      ),
-                                    ],
-                                  );
-                                });
-                          },
-                  ),
-                ],
-              ),
-            );
-          });
-    }
-  }
-
   Future<void> _deletePersonnel() async {
     try {
+      List<String> personnelToDelete = _selectedPersonnel
+          .toSet()
+          .intersection(_allowedPersonnel.toSet())
+          .toList();
+
       await PersonnelServices(ref: ref)
-          .deletePersonnelFromList(_selectedPersonnel);
+          .deletePersonnelFromList(personnelToDelete);
       setState(() {
         _isSelecting = false;
       });
       if (context.mounted) {
         _pop();
       }
+      _showSuccess(personnelToDelete.length, _selectedPersonnel.length);
     } catch (e) {
       if (context.mounted) {
         _showError(e.toString());
       }
     }
+  }
+
+  List<String> _getAllPersonnel() {
+    final List<String> allPersonnel = [];
+    for (final personnel in widget.personnelList) {
+      allPersonnel.add(personnel.uuid);
+    }
+
+    return allPersonnel;
   }
 
   List<String> _getAllowedPersonnel() {
@@ -378,6 +274,23 @@ class PersonnelListViewState extends ConsumerState<PersonnelListView> {
     ScaffoldMessenger.of(context)
         .showSnackBar(SnackBar(content: Text(message)));
   }
+
+  void _showSuccess(int deleted, int selected) {
+    String message = '$deleted personnel deleted.';
+
+    if (deleted < selected) {
+      message = '''
+        $message
+        ${selected - deleted} personnel could not be deleted because they are assigned to a project.
+      ''';
+    }
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        duration: const Duration(seconds: 10),
+      ),
+    );
+  }
 }
 
 class SelectPersonnelTile extends StatelessWidget {
@@ -400,13 +313,27 @@ class SelectPersonnelTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return ListTile(
         title: Text(data.name ?? ''),
-        subtitle: Text(data.role ?? ''),
+        subtitle: PersonnelSubtitle(
+          role: data.role,
+          affiliation: data.affiliation,
+          currentFieldNumber: data.currentFieldNumber,
+        ),
         leading: isSelecting
-            ? ListCheckBox(
-                isDisabled: listedPersonnel.contains(data.uuid),
-                value: selectedPersonnel.contains(data.uuid),
-                onChanged: onChanged,
-              )
+            ? Row(mainAxisSize: MainAxisSize.min, children: [
+                ListCheckBox(
+                  isDisabled: false,
+                  value: selectedPersonnel.contains(data.uuid),
+                  onChanged: onChanged,
+                ),
+                Visibility(
+                    maintainSize: true,
+                    maintainAnimation: true,
+                    maintainState: true,
+                    visible: listedPersonnel.contains(data.uuid),
+                    child: Tooltip(
+                        message: 'Personnel is currently assigned to a project',
+                        child: Icon(Icons.book))),
+              ])
             : const SizedBox.shrink(),
         trailing: IconButton(
           icon: const Icon(Icons.edit_outlined),

--- a/lib/screens/projects/personnel/manage_personnel.dart
+++ b/lib/screens/projects/personnel/manage_personnel.dart
@@ -335,16 +335,18 @@ class SelectPersonnelTile extends StatelessWidget {
                         child: Icon(Icons.book))),
               ])
             : const SizedBox.shrink(),
-        trailing: IconButton(
-          icon: const Icon(Icons.edit_outlined),
-          onPressed: () {
-            Navigator.push(
-                context,
-                MaterialPageRoute(
-                    builder: (context) => EditPersonnelForm(
-                          personnelData: data,
-                        )));
-          },
-        ));
+        trailing: !isSelecting
+            ? IconButton(
+                icon: const Icon(Icons.edit_outlined),
+                onPressed: () {
+                  Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (context) => EditPersonnelForm(
+                                personnelData: data,
+                              )));
+                },
+              )
+            : SizedBox.shrink());
   }
 }

--- a/lib/screens/projects/personnel/personnel.dart
+++ b/lib/screens/projects/personnel/personnel.dart
@@ -49,6 +49,8 @@ class PersonnelList extends ConsumerStatefulWidget {
 
 class PersonnelListState extends ConsumerState<PersonnelList> {
   final ScrollController _scrollController = ScrollController();
+  bool _isSelecting = false;
+  final List<String> _selectedPersonnel = [];
 
   @override
   void dispose() {
@@ -66,6 +68,29 @@ class PersonnelListState extends ConsumerState<PersonnelList> {
             : Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
+                  SelectItemsInterface(
+                    isSelecting: _isSelecting,
+                    onClearPressed: _selectedPersonnel.isEmpty
+                        ? null
+                        : () {
+                            setState(() {
+                              _selectedPersonnel.clear();
+                            });
+                          },
+                    onSelectAllPressed: () {
+                      setState(() {
+                        _selectedPersonnel.clear();
+                        _selectedPersonnel
+                            .addAll(data.map((e) => e.uuid).toList());
+                      });
+                    },
+                    onSelectPressed: () {
+                      setState(() {
+                        _isSelecting = !_isSelecting;
+                        _selectedPersonnel.clear();
+                      });
+                    },
+                  ),
                   Flexible(
                     child: CommonScrollbar(
                       scrollController: _scrollController,
@@ -76,8 +101,27 @@ class PersonnelListState extends ConsumerState<PersonnelList> {
                         itemBuilder: (context, index) {
                           return PersonnelListTile(
                             personnelData: data[index],
-                            trailing: PersonnelMenu(
-                              data: data[index],
+                            isSelecting: _isSelecting,
+                            selectedPersonnel: _selectedPersonnel,
+                            onChanged: (bool? value) {
+                              setState(() {
+                                if (value == true) {
+                                  _selectedPersonnel.add(data[index].uuid);
+                                } else {
+                                  _selectedPersonnel.remove(data[index].uuid);
+                                }
+                              });
+                            },
+                            trailing: IconButton(
+                              icon: const Icon(Icons.edit_outlined),
+                              onPressed: () {
+                                Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                        builder: (context) => EditPersonnelForm(
+                                              personnelData: data[index],
+                                            )));
+                              },
                             ),
                           );
                         },
@@ -86,11 +130,72 @@ class PersonnelListState extends ConsumerState<PersonnelList> {
                   ),
                   const SizedBox(height: 8),
                   const AddPersonnelButton(),
+                  const SizedBox(height: 8),
+                  _isSelecting
+                      ? DeleteItemsButton(
+                          selectedItems: _selectedPersonnel,
+                          itemName: "personnel",
+                          onPressedFunction: () async {
+                            await _deletePersonnel();
+                            setState(() {
+                              _selectedPersonnel.clear();
+                            });
+                          },
+                          customIconButtonText:
+                              'Remove ${_selectedPersonnel.length} personnel from project',
+                          customDialogHeader: 'Remove personnel',
+                          customDialogText:
+                              'Are you sure you want to remove the selected personnel from the project?',
+                          customDialogButtonText: 'Remove',
+                        )
+                      : const SizedBox.shrink(),
                 ],
               );
       },
       loading: () => const CommonProgressIndicator(),
       error: (error, stack) => Text(error.toString()),
+    );
+  }
+
+  Future<void> _deletePersonnel() async {
+    int numberPersonnelDeleted = 0;
+    for (String personnelUuid in _selectedPersonnel) {
+      try {
+        await PersonnelServices(ref: ref).deleteProjectPersonnel(personnelUuid);
+        numberPersonnelDeleted++;
+      } catch (e) {
+        if (e.toString().contains('Personnel is being used') ||
+            e.toString().contains('SqliteException(787)')) {
+          continue;
+        } else {
+          // Something went wrong. Discontinue deleting.
+          _showError(e.toString());
+          break;
+        }
+      }
+    }
+
+    if (context.mounted) {
+      _pop();
+    }
+
+    if (numberPersonnelDeleted < _selectedPersonnel.length) {
+      _showError('${_selectedPersonnel.length - numberPersonnelDeleted} '
+          'personnel could not be removed as they are being '
+          'used by project records.');
+    }
+  }
+
+  void _pop() {
+    Navigator.pop(context);
+  }
+
+  void _showError(String errors) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(errors),
+        duration: const Duration(seconds: 10),
+      ),
     );
   }
 }
@@ -156,10 +261,16 @@ class PersonnelListTile extends StatefulWidget {
   const PersonnelListTile({
     super.key,
     required this.personnelData,
+    required this.isSelecting,
+    required this.selectedPersonnel,
+    required this.onChanged,
     required this.trailing,
   });
 
   final PersonnelData personnelData;
+  final bool isSelecting;
+  final List<String> selectedPersonnel;
+  final void Function(bool?) onChanged;
   final Widget trailing;
 
   @override
@@ -183,21 +294,30 @@ class _PersonnelListTileState extends State<PersonnelListTile> {
 
   @override
   Widget build(BuildContext context) {
+    final personnelData = widget.personnelData;
     return ListTile(
-      leading: SizedBox(
-          height: avatarSize.toDouble(),
-          width: avatarSize.toDouble(),
-          child: AvatarViewer(
-            avatarCtr: _personnelPhotoCtr,
-          )),
+      leading: Row(mainAxisSize: MainAxisSize.min, children: [
+        widget.isSelecting
+            ? ListCheckBox(
+                isDisabled: false,
+                value: widget.selectedPersonnel.contains(personnelData.uuid),
+                onChanged: widget.onChanged)
+            : const SizedBox.shrink(),
+        SizedBox(
+            height: avatarSize.toDouble(),
+            width: avatarSize.toDouble(),
+            child: AvatarViewer(
+              avatarCtr: _personnelPhotoCtr,
+            ))
+      ]),
       title: Text(
-        _getTitle(widget.personnelData.name, widget.personnelData.initial),
+        _getTitle(personnelData.name, personnelData.initial),
         style: Theme.of(context).textTheme.titleMedium,
       ),
       subtitle: PersonnelSubtitle(
-        role: widget.personnelData.role,
-        affiliation: widget.personnelData.affiliation,
-        currentFieldNumber: widget.personnelData.currentFieldNumber,
+        role: personnelData.role,
+        affiliation: personnelData.affiliation,
+        currentFieldNumber: personnelData.currentFieldNumber,
       ),
       trailing: widget.trailing,
     );
@@ -232,25 +352,29 @@ class PersonnelSubtitle extends StatelessWidget {
   Widget build(BuildContext context) {
     return RichText(
         text: TextSpan(children: [
-      role != null
+      (role != null && role != '')
           ? TextSpan(children: [
               const WidgetSpan(
-                  child: TileIcon(icon: Icons.account_circle_outlined),
+                  child: Tooltip(
+                      message: 'Role',
+                      child: TileIcon(icon: Icons.account_circle_outlined)),
                   alignment: PlaceholderAlignment.middle),
               TextSpan(
-                text: '$role ',
+                text: ' $role ',
                 style: Theme.of(context).textTheme.labelLarge,
               ),
             ])
           : const TextSpan(),
-      affiliation != null
+      (affiliation != null && affiliation != '')
           ? TextSpan(
               children: [
                 const WidgetSpan(
-                    child: TileIcon(icon: Icons.business_rounded),
+                    child: Tooltip(
+                        message: 'Affiliation',
+                        child: TileIcon(icon: Icons.business_rounded)),
                     alignment: PlaceholderAlignment.middle),
                 TextSpan(
-                  text: '$affiliation ',
+                  text: ' $affiliation ',
                   style: Theme.of(context).textTheme.labelLarge,
                 ),
               ],
@@ -261,104 +385,17 @@ class PersonnelSubtitle extends StatelessWidget {
           : TextSpan(
               children: [
                 WidgetSpan(
-                    child: TileIcon(icon: MdiIcons.counter),
+                    child: Tooltip(
+                        message: 'Current Field Number',
+                        child: TileIcon(icon: MdiIcons.counter)),
                     alignment: PlaceholderAlignment.middle),
                 TextSpan(
-                  text: '$currentFieldNumber',
+                  text: ' $currentFieldNumber',
                   style: Theme.of(context).textTheme.labelLarge,
                 ),
               ],
             ),
     ]));
-  }
-}
-
-class PersonnelMenu extends ConsumerStatefulWidget {
-  const PersonnelMenu({super.key, required this.data});
-
-  final PersonnelData data;
-
-  @override
-  PersonnelMenuState createState() => PersonnelMenuState();
-}
-
-class PersonnelMenuState extends ConsumerState<PersonnelMenu> {
-  @override
-  Widget build(BuildContext context) {
-    return PopupMenuButton<PersonnelMenuAction>(
-      icon: const Icon(Icons.more_vert_rounded),
-      itemBuilder: (context) => [
-        PopupMenuItem(
-          value: PersonnelMenuAction.edit,
-          child: ListTile(
-            leading: const Icon(Icons.edit_outlined),
-            title: const Text('Edit'),
-            onTap: () {
-              Navigator.of(context).pop();
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) => EditPersonnelForm(
-                    personnelData: widget.data,
-                  ),
-                ),
-              );
-            },
-          ),
-        ),
-        const PopupMenuDivider(),
-        PopupMenuItem(
-            value: PersonnelMenuAction.delete,
-            child: ListTile(
-              leading: Icon(Icons.delete_outline,
-                  color: Theme.of(context).colorScheme.error),
-              title: Text(
-                'Delete',
-                style: TextStyle(color: Theme.of(context).colorScheme.error),
-              ),
-              onTap: () {
-                _deletePersonnel();
-                Navigator.of(context).pop();
-              },
-            )),
-      ],
-    );
-  }
-
-  void _deletePersonnel() {
-    showDeleteAlertOnMenu(
-      context: context,
-      title: 'Delete personnel?',
-      deletePrompt: 'You will delete the personnel for this project.'
-          ' The record will still be available in the database.',
-      onDelete: () async {
-        try {
-          await PersonnelServices(ref: ref)
-              .deleteProjectPersonnel(widget.data.uuid);
-          if (context.mounted) {
-            _pop();
-          }
-        } catch (e) {
-          _showError(e.toString());
-        }
-      },
-    );
-  }
-
-  void _pop() {
-    Navigator.pop(context);
-  }
-
-  void _showError(String errors) {
-    Navigator.of(context).pop();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          errors.contains('SqliteException(787)')
-              ? 'Cannot delete personnel. Being used by other records.'
-              : errors.toString(),
-        ),
-      ),
-    );
   }
 }
 

--- a/lib/screens/projects/personnel/personnel.dart
+++ b/lib/screens/projects/personnel/personnel.dart
@@ -129,10 +129,9 @@ class PersonnelListState extends ConsumerState<PersonnelList> {
                     ),
                   ),
                   const SizedBox(height: 8),
-                  const AddPersonnelButton(),
-                  const SizedBox(height: 8),
-                  _isSelecting
-                      ? DeleteItemsButton(
+                  !_isSelecting
+                      ? const AddPersonnelButton()
+                      : DeleteItemsButton(
                           selectedItems: _selectedPersonnel,
                           itemName: "personnel",
                           onPressedFunction: () async {
@@ -148,7 +147,6 @@ class PersonnelListState extends ConsumerState<PersonnelList> {
                               'Are you sure you want to remove the selected personnel from the project?',
                           customDialogButtonText: 'Remove',
                         )
-                      : const SizedBox.shrink(),
                 ],
               );
       },

--- a/lib/screens/projects/personnel/personnel.dart
+++ b/lib/screens/projects/personnel/personnel.dart
@@ -295,18 +295,17 @@ class _PersonnelListTileState extends State<PersonnelListTile> {
     final personnelData = widget.personnelData;
     return ListTile(
       leading: Row(mainAxisSize: MainAxisSize.min, children: [
-        widget.isSelecting
-            ? ListCheckBox(
+        !widget.isSelecting
+            ? SizedBox(
+                height: avatarSize.toDouble(),
+                width: avatarSize.toDouble(),
+                child: AvatarViewer(
+                  avatarCtr: _personnelPhotoCtr,
+                ))
+            : ListCheckBox(
                 isDisabled: false,
                 value: widget.selectedPersonnel.contains(personnelData.uuid),
-                onChanged: widget.onChanged)
-            : const SizedBox.shrink(),
-        SizedBox(
-            height: avatarSize.toDouble(),
-            width: avatarSize.toDouble(),
-            child: AvatarViewer(
-              avatarCtr: _personnelPhotoCtr,
-            ))
+                onChanged: widget.onChanged),
       ]),
       title: Text(
         _getTitle(personnelData.name, personnelData.initial),
@@ -317,7 +316,7 @@ class _PersonnelListTileState extends State<PersonnelListTile> {
         affiliation: personnelData.affiliation,
         currentFieldNumber: personnelData.currentFieldNumber,
       ),
-      trailing: widget.trailing,
+      trailing: !widget.isSelecting ? widget.trailing : SizedBox.shrink(),
     );
   }
 

--- a/lib/screens/projects/personnel/personnel_form.dart
+++ b/lib/screens/projects/personnel/personnel_form.dart
@@ -2,7 +2,6 @@ import 'package:nahpu/services/personnel_services.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/services/providers/personnel.dart';
-import 'package:nahpu/screens/projects/dashboard.dart';
 import 'package:nahpu/screens/projects/personnel/avatars.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/fields.dart';
@@ -219,33 +218,38 @@ class PersonnelFormPageState extends ConsumerState<PersonnelFormPage> {
           const SizedBox(
             height: 16,
           ),
-          Wrap(
-            spacing: 16,
-            children: [
-              SecondaryButton(
-                text: 'Cancel',
-                onPressed: () {
+          FormButtonWithDelete(
+            isEditing: widget.isEditing,
+            onDeleted: () async {
+              try {
+                await _deletePersonnel();
+                ref.invalidate(projectPersonnelProvider);
+                ref.invalidate(personnelFormValidatorProvider);
+                if (context.mounted) {
                   Navigator.of(context).pop();
-                },
-              ),
-              FormElevButton(
-                label: widget.isEditing ? 'Update' : 'Add',
-                icon: widget.isEditing ? Icons.check : Icons.add,
-                enabled: _validateForm(),
-                onPressed: () async {
-                  widget.isEditing ? _updatePersonnel() : _addPersonnel();
-                  ref.invalidate(projectPersonnelProvider);
-                  ref.invalidate(personnelFormValidatorProvider);
-                  if (context.mounted) {
-                    Navigator.of(context).pushReplacement(
-                      MaterialPageRoute(
-                        builder: (context) => const Dashboard(),
-                      ),
-                    );
+                }
+              } catch (e) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(
+                      content: Text('Cannot delete personnel.'
+                          ' They are assigned to a project.'),
+                    ),
+                  );
+                }
+              }
+            },
+            onSubmitted: _validateForm()
+                ? () async {
+                    widget.isEditing
+                        ? _updatePersonnel()
+                        : await _addPersonnel();
+                    PersonnelServices(ref: ref).invalidatePersonnel();
+                    if (context.mounted) {
+                      Navigator.of(context).pop();
+                    }
                   }
-                },
-              ),
-            ],
+                : null,
           ),
         ],
       ),
@@ -328,6 +332,10 @@ class PersonnelFormPageState extends ConsumerState<PersonnelFormPage> {
       personnelUuid: db.Value(widget.personnelUuid),
       projectUuid: db.Value(projectUuid),
     ));
+  }
+
+  Future<void> _deletePersonnel() async {
+    await PersonnelServices(ref: ref).deletePersonnel(widget.personnelUuid);
   }
 
   int _getCollectorNumber() {

--- a/lib/screens/projects/taxonomy/taxon_list.dart
+++ b/lib/screens/projects/taxonomy/taxon_list.dart
@@ -217,20 +217,22 @@ class TaxonListViewState extends ConsumerState<TaxonListView> {
                           },
                         )
                       : null,
-                  trailing: IconButton(
-                    icon: const Icon(Icons.edit_outlined),
-                    onPressed: () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (context) => EditTaxon(
-                            taxonId: widget.taxonList[index].id,
-                            ctr: TaxonRegistryCtrModel.fromData(
-                                widget.taxonList[index]),
-                          ),
-                        ),
-                      );
-                    },
-                  ),
+                  trailing: !_isSelecting
+                      ? IconButton(
+                          icon: const Icon(Icons.edit_outlined),
+                          onPressed: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (context) => EditTaxon(
+                                  taxonId: widget.taxonList[index].id,
+                                  ctr: TaxonRegistryCtrModel.fromData(
+                                      widget.taxonList[index]),
+                                ),
+                              ),
+                            );
+                          },
+                        )
+                      : SizedBox.shrink(),
                 );
               },
             ),

--- a/lib/screens/projects/taxonomy/taxon_list.dart
+++ b/lib/screens/projects/taxonomy/taxon_list.dart
@@ -153,47 +153,34 @@ class TaxonListViewState extends ConsumerState<TaxonListView> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: [
-        Row(children: [
-          Visibility(
-            visible: _isSelecting,
-            child: TextButton(
-              onPressed: _selectedTaxon.isEmpty
+        SelectItemsInterface(
+          isSelecting: _isSelecting,
+          onClearPressed: _selectedTaxon.isEmpty
+              ? null
+              : () {
+                  setState(() {
+                    _selectedTaxon.clear();
+                  });
+                },
+          onSelectAllPressed:
+              _selectedTaxon.length == widget.taxonList.length ||
+                      _selectedTaxon.length == _allowedTaxa.length
                   ? null
                   : () {
                       setState(() {
                         _selectedTaxon.clear();
+                        _selectedTaxon.addAll(_allowedTaxa);
                       });
                     },
-              child: const Text('Clear'),
-            ),
-          ),
-          Visibility(
-              visible: _isSelecting,
-              child: TextButton(
-                onPressed: _selectedTaxon.length == widget.taxonList.length ||
-                        _selectedTaxon.length == _allowedTaxa.length
-                    ? null
-                    : () {
-                        setState(() {
-                          _selectedTaxon.clear();
-                          _selectedTaxon.addAll(_allowedTaxa);
-                        });
-                      },
-                child: const Text('Select all'),
-              )),
-          const Spacer(),
-          TextButton(
-            onPressed: () async {
-              _usedTaxon = await _getUsedTaxa();
-              _allowedTaxa = _getAllowedTaxa();
-              setState(() {
-                _isSelecting = !_isSelecting;
-                _selectedTaxon.clear();
-              });
-            },
-            child: Text(_isSelecting ? 'Cancel' : 'Select'),
-          ),
-        ]),
+          onSelectPressed: () async {
+            _usedTaxon = await _getUsedTaxa();
+            _allowedTaxa = _getAllowedTaxa();
+            setState(() {
+              _isSelecting = !_isSelecting;
+              _selectedTaxon.clear();
+            });
+          },
+        ),
         Expanded(
           child: CommonScrollbar(
             scrollController: _scrollController,
@@ -251,9 +238,10 @@ class TaxonListViewState extends ConsumerState<TaxonListView> {
         ),
         const SizedBox(height: 8),
         _isSelecting
-            ? DeleteTaxonButton(
-                selectedTaxon: _selectedTaxon,
-                onPressed: () async {
+            ? DeleteItemsButton(
+                selectedItems: _selectedTaxon,
+                itemName: _selectedTaxon.length == 1 ? 'taxon' : 'taxa',
+                onPressedFunction: () async {
                   await _deleteTaxon();
                   setState(() {
                     _selectedTaxon.clear();
@@ -284,68 +272,5 @@ class TaxonListViewState extends ConsumerState<TaxonListView> {
 
   Future<void> _deleteTaxon() async {
     await TaxonomyServices(ref: ref).deleteTaxonFromList(_selectedTaxon);
-  }
-}
-
-class DeleteTaxonButton extends StatelessWidget {
-  const DeleteTaxonButton({
-    super.key,
-    required this.selectedTaxon,
-    required this.onPressed,
-  });
-
-  final List<int> selectedTaxon;
-  final VoidCallback? onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        IconButton(
-          color: Theme.of(context).colorScheme.error,
-          onPressed: selectedTaxon.isEmpty
-              ? null
-              : () {
-                  showDialog(
-                      context: context,
-                      builder: (context) {
-                        return AlertDialog(
-                          title: const Text('Delete taxon'),
-                          content: const Text(
-                              'Are you sure you want to delete the selected taxon?'),
-                          actions: [
-                            TextButton(
-                              onPressed: () {
-                                Navigator.of(context).pop();
-                              },
-                              child: const Text('Cancel'),
-                            ),
-                            TextButton(
-                              onPressed: onPressed,
-                              child: Text('Delete',
-                                  style: TextStyle(
-                                    color: Theme.of(context).colorScheme.error,
-                                  )),
-                            ),
-                          ],
-                        );
-                      });
-                },
-          icon: const Icon(Icons.delete_outline),
-        ),
-        Visibility(
-            visible: selectedTaxon.isNotEmpty,
-            child: Text('Delete ${_taxonCount()}',
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.error,
-                )))
-      ],
-    );
-  }
-
-  String _taxonCount() {
-    return selectedTaxon.length == 1
-        ? '1 taxon'
-        : '${selectedTaxon.length} taxa';
   }
 }

--- a/lib/screens/shared/buttons.dart
+++ b/lib/screens/shared/buttons.dart
@@ -132,7 +132,7 @@ class FormButtonWithDelete extends StatelessWidget {
 
   final bool isEditing;
   final VoidCallback onDeleted;
-  final VoidCallback onSubmitted;
+  final VoidCallback? onSubmitted;
 
   @override
   Widget build(BuildContext context) {
@@ -249,7 +249,7 @@ class FormButton extends StatelessWidget {
   });
 
   final bool isEditing;
-  final VoidCallback onSubmitted;
+  final VoidCallback? onSubmitted;
 
   @override
   Widget build(BuildContext context) {
@@ -424,5 +424,74 @@ class ListCheckBox extends StatelessWidget {
         ),
         value: value,
         onChanged: isDisabled ? null : onChanged);
+  }
+}
+
+class DeleteItemsButton extends StatelessWidget {
+  const DeleteItemsButton({
+    super.key,
+    required this.selectedItems,
+    required this.itemName,
+    required this.onPressedFunction,
+    this.customIconButtonText,
+    this.customDialogHeader,
+    this.customDialogText,
+    this.customDialogButtonText,
+  });
+
+  final List<dynamic> selectedItems;
+  final String itemName;
+  final VoidCallback? onPressedFunction;
+  final String? customIconButtonText;
+  final String? customDialogHeader;
+  final String? customDialogText;
+  final String? customDialogButtonText;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        IconButton(
+          color: Theme.of(context).colorScheme.error,
+          onPressed: selectedItems.isEmpty
+              ? null
+              : () {
+                  showDialog(
+                      context: context,
+                      builder: (context) {
+                        return AlertDialog(
+                          title: Text(customDialogHeader ?? 'Delete $itemName'),
+                          content: Text(customDialogText ??
+                              'Are you sure you want to delete the selected $itemName?'),
+                          actions: [
+                            TextButton(
+                              onPressed: () {
+                                Navigator.of(context).pop();
+                              },
+                              child: const Text('Cancel'),
+                            ),
+                            TextButton(
+                              onPressed: onPressedFunction,
+                              child: Text(customDialogButtonText ?? 'Delete',
+                                  style: TextStyle(
+                                    color: Theme.of(context).colorScheme.error,
+                                  )),
+                            ),
+                          ],
+                        );
+                      });
+                },
+          icon: const Icon(Icons.delete_outline),
+        ),
+        Visibility(
+            visible: selectedItems.isNotEmpty,
+            child: Text(
+                customIconButtonText ??
+                    'Delete ${selectedItems.length} $itemName',
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                )))
+      ],
+    );
   }
 }

--- a/lib/screens/shared/buttons.dart
+++ b/lib/screens/shared/buttons.dart
@@ -451,6 +451,14 @@ class DeleteItemsButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
+        Visibility(
+            visible: selectedItems.isNotEmpty,
+            child: Text(
+                customIconButtonText ??
+                    'Delete ${selectedItems.length} $itemName',
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                ))),
         IconButton(
           color: Theme.of(context).colorScheme.error,
           onPressed: selectedItems.isEmpty
@@ -483,14 +491,6 @@ class DeleteItemsButton extends StatelessWidget {
                 },
           icon: const Icon(Icons.delete_outline),
         ),
-        Visibility(
-            visible: selectedItems.isNotEmpty,
-            child: Text(
-                customIconButtonText ??
-                    'Delete ${selectedItems.length} $itemName',
-                style: TextStyle(
-                  color: Theme.of(context).colorScheme.error,
-                )))
       ],
     );
   }

--- a/lib/screens/shared/common.dart
+++ b/lib/screens/shared/common.dart
@@ -163,7 +163,7 @@ class SelectItemsInterface extends StatelessWidget {
       const Spacer(),
       TextButton(
         onPressed: onSelectPressed,
-        child: Text(isSelecting ? 'Cancel' : 'Select'),
+        child: Text(isSelecting ? 'Done' : 'Select'),
       )
     ]);
   }

--- a/lib/screens/shared/common.dart
+++ b/lib/screens/shared/common.dart
@@ -72,12 +72,11 @@ class CommonLineDivider extends StatelessWidget {
 }
 
 class CommonAlertDialog extends StatelessWidget {
-  const CommonAlertDialog({
-    super.key,
-    required this.titleText,
-    this.descText,
-    required this.confirmFunction
-  });
+  const CommonAlertDialog(
+      {super.key,
+      required this.titleText,
+      this.descText,
+      required this.confirmFunction});
 
   final String titleText;
   final String? descText;
@@ -87,26 +86,25 @@ class CommonAlertDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: Text(titleText),
-      content: descText == null ? null: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 350),
-        child:
-          Text(descText!)),
+      content: descText == null
+          ? null
+          : ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 350),
+              child: Text(descText!)),
       actions: [
         TextButton(
-          onPressed: () {
-            Navigator.pop(context);
-          }, 
-          child: const Text('Cancel')
-        ),
-        TextButton(
-          onPressed: () {
-            confirmFunction();
-            if (context.mounted) {
+            onPressed: () {
               Navigator.pop(context);
-            }
-          }, 
-          child: const Text('OK')
-        )
+            },
+            child: const Text('Cancel')),
+        TextButton(
+            onPressed: () {
+              confirmFunction();
+              if (context.mounted) {
+                Navigator.pop(context);
+              }
+            },
+            child: const Text('OK'))
       ],
     );
   }
@@ -128,5 +126,45 @@ class TileSvgIcon extends StatelessWidget {
         BlendMode.srcIn,
       ),
     );
+  }
+}
+
+class SelectItemsInterface extends StatelessWidget {
+  const SelectItemsInterface({
+    super.key,
+    required this.isSelecting,
+    required this.onClearPressed,
+    required this.onSelectAllPressed,
+    required this.onSelectPressed,
+  });
+
+  final bool isSelecting;
+  final VoidCallback? onClearPressed;
+  final VoidCallback? onSelectAllPressed;
+  final VoidCallback? onSelectPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(children: [
+      Visibility(
+        visible: isSelecting,
+        child: TextButton(
+          onPressed: onClearPressed,
+          child: const Text('Clear'),
+        ),
+      ),
+      Visibility(
+        visible: isSelecting,
+        child: TextButton(
+          onPressed: onSelectAllPressed,
+          child: const Text('Select all'),
+        ),
+      ),
+      const Spacer(),
+      TextButton(
+        onPressed: onSelectPressed,
+        child: Text(isSelecting ? 'Cancel' : 'Select'),
+      )
+    ]);
   }
 }

--- a/lib/screens/sites/components/coordinates.dart
+++ b/lib/screens/sites/components/coordinates.dart
@@ -186,8 +186,11 @@ class CoordinateListState extends ConsumerState<CoordinateList> {
                               leading: Row(
                                   mainAxisSize: MainAxisSize.min,
                                   children: [
-                                    _isSelecting
-                                        ? ListCheckBox(
+                                    !_isSelecting
+                                        ? CoordinateTileIcon(
+                                            name:
+                                                data[index].nameId ?? 'unknown')
+                                        : ListCheckBox(
                                             isDisabled: false,
                                             value: _selectedCoordinates
                                                 .contains(data[index].id),
@@ -204,21 +207,20 @@ class CoordinateListState extends ConsumerState<CoordinateList> {
                                                 }
                                               });
                                             },
-                                          )
-                                        : SizedBox.shrink(),
-                                    CoordinateTileIcon(
-                                        name: data[index].nameId ?? 'unknown')
+                                          ),
                                   ]),
                               title: CoordinateTitle(
                                   coordinateId: data[index].nameId),
                               subtitle:
                                   CoordinateSubtitle(coordinate: data[index]),
-                              trailing: CoordinateMenu(
-                                coordinateId: data[index].id!,
-                                siteId: data[index].siteID!,
-                                coordCtr:
-                                    CoordinateCtrModel.fromData(data[index]),
-                              ),
+                              trailing: !_isSelecting
+                                  ? CoordinateMenu(
+                                      coordinateId: data[index].id!,
+                                      siteId: data[index].siteID!,
+                                      coordCtr: CoordinateCtrModel.fromData(
+                                          data[index]),
+                                    )
+                                  : SizedBox.shrink(),
                             );
                           },
                         )),

--- a/lib/screens/sites/components/coordinates.dart
+++ b/lib/screens/sites/components/coordinates.dart
@@ -122,7 +122,7 @@ class AddCoordinateButtonState extends ConsumerState<AddCoordinateButton> {
   }
 }
 
-class CoordinateList extends ConsumerWidget {
+class CoordinateList extends ConsumerStatefulWidget {
   const CoordinateList({
     super.key,
     required this.sideId,
@@ -131,15 +131,48 @@ class CoordinateList extends ConsumerWidget {
   final int sideId;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final coordinates = ref.watch(coordinateBySiteProvider(sideId));
+  CoordinateListState createState() => CoordinateListState();
+}
+
+class CoordinateListState extends ConsumerState<CoordinateList> {
+  bool _isSelecting = false;
+  final List<int> _selectedCoordinates = [];
+
+  @override
+  Widget build(BuildContext context) {
+    final coordinates = ref.watch(coordinateBySiteProvider(widget.sideId));
     ScrollController scrollController = ScrollController();
     return coordinates.when(
       data: (data) {
         return data.isEmpty
-            ? EmptyCoordinateList(siteId: sideId)
+            ? EmptyCoordinateList(siteId: widget.sideId)
             : Column(
                 children: [
+                  SelectItemsInterface(
+                    isSelecting: _isSelecting,
+                    onClearPressed: _selectedCoordinates.isEmpty
+                        ? null
+                        : () {
+                            setState(() {
+                              _selectedCoordinates.clear();
+                            });
+                          },
+                    onSelectAllPressed: () {
+                      setState(() {
+                        _selectedCoordinates.clear();
+                        _selectedCoordinates.addAll(data
+                            .where((e) => e.id != null)
+                            .map((e) => e.id!)
+                            .toList());
+                      });
+                    },
+                    onSelectPressed: () {
+                      setState(() {
+                        _isSelecting = !_isSelecting;
+                        _selectedCoordinates.clear();
+                      });
+                    },
+                  ),
                   Flexible(
                     child: CommonScrollbar(
                         scrollController: scrollController,
@@ -150,8 +183,32 @@ class CoordinateList extends ConsumerWidget {
                           itemBuilder: (context, index) {
                             return ListTile(
                               dense: true,
-                              leading: CoordinateTileIcon(
-                                  name: data[index].nameId ?? 'unknown'),
+                              leading: Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: [
+                                    _isSelecting
+                                        ? ListCheckBox(
+                                            isDisabled: false,
+                                            value: _selectedCoordinates
+                                                .contains(data[index].id),
+                                            onChanged: (bool? value) {
+                                              setState(() {
+                                                if (data[index].id != null) {
+                                                  if (value == true) {
+                                                    _selectedCoordinates
+                                                        .add(data[index].id!);
+                                                  } else {
+                                                    _selectedCoordinates
+                                                        .remove(data[index].id);
+                                                  }
+                                                }
+                                              });
+                                            },
+                                          )
+                                        : SizedBox.shrink(),
+                                    CoordinateTileIcon(
+                                        name: data[index].nameId ?? 'unknown')
+                                  ]),
                               title: CoordinateTitle(
                                   coordinateId: data[index].nameId),
                               subtitle:
@@ -167,13 +224,54 @@ class CoordinateList extends ConsumerWidget {
                         )),
                   ),
                   const SizedBox(height: 8),
-                  AddCoordinateButton(siteId: sideId),
+                  AddCoordinateButton(siteId: widget.sideId),
+                  const SizedBox(height: 8),
+                  _isSelecting
+                      ? DeleteItemsButton(
+                          selectedItems: _selectedCoordinates,
+                          itemName: 'coordinates',
+                          onPressedFunction: () async {
+                            await _deleteCoodinates();
+                            setState(() {
+                              _selectedCoordinates.clear();
+                            });
+                          })
+                      : const SizedBox.shrink(),
                 ],
               );
       },
       loading: () => const CommonProgressIndicator(),
       error: (error, stack) => Text(error.toString()),
     );
+  }
+
+  Future<void> _deleteCoodinates() async {
+    try {
+      CoordinateServices(ref: ref)
+          .deleteCoordinatesFromList(_selectedCoordinates);
+      ref.invalidate(coordinateBySiteProvider);
+      setState(() {
+        _isSelecting = false;
+      });
+      if (context.mounted) {
+        _pop();
+      }
+    } catch (e) {
+      if (context.mounted) {
+        _showError(e.toString());
+      }
+    }
+  }
+
+  void _pop() {
+    Navigator.pop(context);
+  }
+
+  void _showError(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(message),
+      duration: const Duration(seconds: 10),
+    ));
   }
 }
 

--- a/lib/screens/sites/components/coordinates.dart
+++ b/lib/screens/sites/components/coordinates.dart
@@ -224,10 +224,9 @@ class CoordinateListState extends ConsumerState<CoordinateList> {
                         )),
                   ),
                   const SizedBox(height: 8),
-                  AddCoordinateButton(siteId: widget.sideId),
-                  const SizedBox(height: 8),
-                  _isSelecting
-                      ? DeleteItemsButton(
+                  !_isSelecting
+                      ? AddCoordinateButton(siteId: widget.sideId)
+                      : DeleteItemsButton(
                           selectedItems: _selectedCoordinates,
                           itemName: 'coordinates',
                           onPressedFunction: () async {
@@ -235,8 +234,7 @@ class CoordinateListState extends ConsumerState<CoordinateList> {
                             setState(() {
                               _selectedCoordinates.clear();
                             });
-                          })
-                      : const SizedBox.shrink(),
+                          }),
                 ],
               );
       },

--- a/lib/screens/specimens/shared/specimen_parts.dart
+++ b/lib/screens/specimens/shared/specimen_parts.dart
@@ -194,8 +194,12 @@ class PartListState extends ConsumerState<PartList> {
                           return ListTile(
                             leading:
                                 Row(mainAxisSize: MainAxisSize.min, children: [
-                              _isSelecting
-                                  ? ListCheckBox(
+                              !_isSelecting
+                                  ? PartIcon(
+                                      partType: part.type ?? 'unknown',
+                                      catalogFmt: widget.catalogFmt,
+                                    )
+                                  : ListCheckBox(
                                       isDisabled: false,
                                       value: _selectedparts.contains(part.id),
                                       onChanged: (bool? value) {
@@ -208,12 +212,7 @@ class PartListState extends ConsumerState<PartList> {
                                             }
                                           });
                                         }
-                                      })
-                                  : const SizedBox.shrink(),
-                              PartIcon(
-                                partType: part.type ?? 'unknown',
-                                catalogFmt: widget.catalogFmt,
-                              )
+                                      }),
                             ]),
                             title: PartTitle(
                               partType: part.type,
@@ -222,20 +221,23 @@ class PartListState extends ConsumerState<PartList> {
                               preparator: part.personnelId,
                             ),
                             subtitle: PartSubTitle(part: part),
-                            trailing: IconButton(
-                              icon: const Icon(Icons.edit_outlined),
-                              onPressed: () {
-                                Navigator.of(context).push(
-                                  MaterialPageRoute(
-                                    builder: (context) => EditPart(
-                                      specimenUuid: widget.specimenUuid,
-                                      specimenPartId: part.id,
-                                      partCtr: PartFormCtrModel.fromData(part),
-                                    ),
-                                  ),
-                                );
-                              },
-                            ),
+                            trailing: !_isSelecting
+                                ? IconButton(
+                                    icon: const Icon(Icons.edit_outlined),
+                                    onPressed: () {
+                                      Navigator.of(context).push(
+                                        MaterialPageRoute(
+                                          builder: (context) => EditPart(
+                                            specimenUuid: widget.specimenUuid,
+                                            specimenPartId: part.id,
+                                            partCtr:
+                                                PartFormCtrModel.fromData(part),
+                                          ),
+                                        ),
+                                      );
+                                    },
+                                  )
+                                : SizedBox.shrink(),
                           );
                         },
                       ),

--- a/lib/screens/specimens/shared/specimen_parts.dart
+++ b/lib/screens/specimens/shared/specimen_parts.dart
@@ -242,10 +242,9 @@ class PartListState extends ConsumerState<PartList> {
                     ),
                   ),
                   const SizedBox(height: 8),
-                  AddPartButton(specimenUuid: widget.specimenUuid),
-                  const SizedBox(height: 8),
-                  _isSelecting
-                      ? DeleteItemsButton(
+                  !_isSelecting
+                      ? AddPartButton(specimenUuid: widget.specimenUuid)
+                      : DeleteItemsButton(
                           selectedItems: _selectedparts,
                           itemName:
                               'specimen ${_selectedparts.length == 1 ? 'part' : 'parts'}',
@@ -254,8 +253,7 @@ class PartListState extends ConsumerState<PartList> {
                             setState(() {
                               _selectedparts.clear();
                             });
-                          })
-                      : const SizedBox.shrink(),
+                          }),
                 ],
               );
       },

--- a/lib/screens/specimens/shared/specimen_parts.dart
+++ b/lib/screens/specimens/shared/specimen_parts.dart
@@ -139,6 +139,8 @@ class PartList extends ConsumerStatefulWidget {
 
 class PartListState extends ConsumerState<PartList> {
   final ScrollController _scrollController = ScrollController();
+  bool _isSelecting = false;
+  final List<int> _selectedparts = [];
 
   @override
   void dispose() {
@@ -156,6 +158,30 @@ class PartListState extends ConsumerState<PartList> {
             ? EmptyPart(specimenUuid: widget.specimenUuid)
             : Column(
                 children: [
+                  SelectItemsInterface(
+                      isSelecting: _isSelecting,
+                      onClearPressed: _selectedparts.isEmpty
+                          ? null
+                          : () {
+                              setState(() {
+                                _selectedparts.clear();
+                              });
+                            },
+                      onSelectAllPressed: () {
+                        setState(() {
+                          _selectedparts.clear();
+                          _selectedparts.addAll(data
+                              .where((e) => e.id != null)
+                              .map((e) => e.id!)
+                              .toList());
+                        });
+                      },
+                      onSelectPressed: () {
+                        setState(() {
+                          _isSelecting = !_isSelecting;
+                          _selectedparts.clear();
+                        });
+                      }),
                   Flexible(
                     child: CommonScrollbar(
                       scrollController: _scrollController,
@@ -166,10 +192,29 @@ class PartListState extends ConsumerState<PartList> {
                         itemBuilder: (context, index) {
                           final part = data[index];
                           return ListTile(
-                            leading: PartIcon(
-                              partType: part.type ?? 'unknown',
-                              catalogFmt: widget.catalogFmt,
-                            ),
+                            leading:
+                                Row(mainAxisSize: MainAxisSize.min, children: [
+                              _isSelecting
+                                  ? ListCheckBox(
+                                      isDisabled: false,
+                                      value: _selectedparts.contains(part.id),
+                                      onChanged: (bool? value) {
+                                        if (part.id != null) {
+                                          setState(() {
+                                            if (value == true) {
+                                              _selectedparts.add(part.id!);
+                                            } else {
+                                              _selectedparts.remove(part.id);
+                                            }
+                                          });
+                                        }
+                                      })
+                                  : const SizedBox.shrink(),
+                              PartIcon(
+                                partType: part.type ?? 'unknown',
+                                catalogFmt: widget.catalogFmt,
+                              )
+                            ]),
                             title: PartTitle(
                               partType: part.type,
                               partCount: part.count.toString(),
@@ -198,12 +243,53 @@ class PartListState extends ConsumerState<PartList> {
                   ),
                   const SizedBox(height: 8),
                   AddPartButton(specimenUuid: widget.specimenUuid),
+                  const SizedBox(height: 8),
+                  _isSelecting
+                      ? DeleteItemsButton(
+                          selectedItems: _selectedparts,
+                          itemName:
+                              'specimen ${_selectedparts.length == 1 ? 'part' : 'parts'}',
+                          onPressedFunction: () async {
+                            await _deleteParts();
+                            setState(() {
+                              _selectedparts.clear();
+                            });
+                          })
+                      : const SizedBox.shrink(),
                 ],
               );
       },
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (err, stack) => Text('Error: $err'),
     );
+  }
+
+  Future<void> _deleteParts() async {
+    try {
+      await SpecimenServices(ref: ref)
+          .deleteSpecimenPartsFromList(_selectedparts);
+      setState(() {
+        _isSelecting = false;
+      });
+      if (context.mounted) {
+        _pop();
+      }
+    } catch (e) {
+      if (context.mounted) {
+        _showError(e.toString());
+      }
+    }
+  }
+
+  void _pop() {
+    Navigator.pop(context);
+  }
+
+  void _showError(String message) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text(message),
+      duration: const Duration(seconds: 10),
+    ));
   }
 }
 

--- a/lib/services/collevent_services.dart
+++ b/lib/services/collevent_services.dart
@@ -145,6 +145,10 @@ class CollEventServices extends AppServices {
     }
   }
 
+  Future<void> deleteCollEffortFromList(List<int> collEffortList) async {
+    await CollEffortQuery(dbAccess).deleteCollEffortsFromList(collEffortList);
+  }
+
   Future<void> deleteAllCollEvents(String projectUuid) async {
     try {
       List<CollEventData> collEvents = await getAllCollEvents();
@@ -164,6 +168,11 @@ class CollEventServices extends AppServices {
   Future<void> deleteCollPersonnel(int id) async {
     await CollPersonnelQuery(dbAccess).deleteCollPersonnel(id);
     invalidateCollPersonnel();
+  }
+
+  Future<void> deleteCollPersonnelFromList(List<int> collEffortList) async {
+    await CollPersonnelQuery(dbAccess)
+        .deleteCollPersonnelFromList(collEffortList);
   }
 
   void invalidateCollEvent() {

--- a/lib/services/database/collevent_queries.dart
+++ b/lib/services/database/collevent_queries.dart
@@ -97,6 +97,10 @@ class CollEffortQuery extends DatabaseAccessor<Database>
     return (delete(collEffort)..where((t) => t.id.equals(id))).go();
   }
 
+  Future<void> deleteCollEffortsFromList(List<int> ids) {
+    return (delete(collEffort)..where((t) => t.id.isIn(ids))).go();
+  }
+
   Future<void> deleteCollEffortByEventId(int eventId) {
     return (delete(collEffort)..where((t) => t.eventID.equals(eventId))).go();
   }
@@ -151,6 +155,10 @@ class CollPersonnelQuery extends DatabaseAccessor<Database>
 
   Future<void> deleteCollPersonnel(int personnelId) {
     return (delete(collPersonnel)..where((t) => t.id.equals(personnelId))).go();
+  }
+
+  Future<void> deleteCollPersonnelFromList(List<int> personnelIds) {
+    return (delete(collPersonnel)..where((t) => t.id.isIn(personnelIds))).go();
   }
 
   Future<void> deleteAllEventPersonnel(int eventId) {

--- a/lib/services/database/coordinate_queries.dart
+++ b/lib/services/database/coordinate_queries.dart
@@ -37,6 +37,10 @@ class CoordinateQuery extends DatabaseAccessor<Database>
     return (delete(coordinate)..where((t) => t.id.equals(id))).go();
   }
 
+  Future<void> deleteCoordinates(List<int> ids) {
+    return (delete(coordinate)..where((t) => t.id.isIn(ids))).go();
+  }
+
   Future<void> deleteAllCoordinates() {
     return delete(coordinate).go();
   }

--- a/lib/services/database/specimen_queries.dart
+++ b/lib/services/database/specimen_queries.dart
@@ -329,6 +329,10 @@ class SpecimenPartQuery extends DatabaseAccessor<Database>
     return (delete(specimenPart)..where((t) => t.id.equals(partId))).go();
   }
 
+  Future<void> deleteSpecimenPartsFromList(List<int> partIds) {
+    return (delete(specimenPart)..where((t) => t.id.isIn(partIds))).go();
+  }
+
   Future<void> deleteAllSpecimenParts(String specimenUuid) {
     return (delete(specimenPart)
           ..where((t) => t.specimenUuid.equals(specimenUuid)))

--- a/lib/services/personnel_services.dart
+++ b/lib/services/personnel_services.dart
@@ -83,7 +83,7 @@ class PersonnelServices extends AppServices {
         .getPersonnelByProjectUuid(projectUuid);
   }
 
-  Future<void> deleteProjectPersonnel(String personnelUuid) async {
+  Future<(bool, String)> personnelUsedBy(String personnelUuid) async {
     bool isUsedInPersonnel = await PersonnelQuery(dbAccess)
         .isPersonnelUsedBySpecimenRecords(
             projectUuid: currentProjectUuid, personnelUuid: personnelUuid);
@@ -95,6 +95,16 @@ class PersonnelServices extends AppServices {
       recordType = isUsedInPersonnel && isUsedInCollEvent
           ? 'specimen and collection event'
           : recordType;
+      return (true, recordType);
+    }
+
+    return (false, '');
+  }
+
+  Future<void> deleteProjectPersonnel(String personnelUuid) async {
+    var (inUse, recordType) = await personnelUsedBy(personnelUuid);
+
+    if (inUse) {
       throw Exception(
           'Failed to delete! Personnel is being used in the $recordType records.');
     } else {

--- a/lib/services/site_services.dart
+++ b/lib/services/site_services.dart
@@ -185,6 +185,10 @@ class CoordinateServices extends AppServices {
   Future<void> deleteCoordinate(int coordinateId) async {
     await CoordinateQuery(dbAccess).deleteCoordinate(coordinateId);
   }
+
+  Future<void> deleteCoordinatesFromList(List<int> coordinatesList) async {
+    await CoordinateQuery(dbAccess).deleteCoordinates(coordinatesList);
+  }
 }
 
 class GeoLocationServices {

--- a/lib/services/specimen_services.dart
+++ b/lib/services/specimen_services.dart
@@ -340,8 +340,13 @@ class SpecimenServices extends AppServices {
     await SpecimenPartQuery(dbAccess).deleteAllSpecimenParts(specimenUuid);
   }
 
-  void deleteSpecimenPart(int partId) {
-    SpecimenPartQuery(dbAccess).deleteSpecimenPart(partId);
+  Future<void> deleteSpecimenPart(int partId) async {
+    await SpecimenPartQuery(dbAccess).deleteSpecimenPart(partId);
+    ref.invalidate(partBySpecimenProvider);
+  }
+
+  Future<void> deleteSpecimenPartsFromList(List<int> partIds) async {
+    await SpecimenPartQuery(dbAccess).deleteSpecimenPartsFromList(partIds);
     ref.invalidate(partBySpecimenProvider);
   }
 


### PR DESCRIPTION
Adds support for multi-select and delete or records across most of the app:

* Taxa
* Personnel
* Project Personnel
* Sites > Coordinates
* Events > Efforts
* Events > Personnel
* Specimens > Specimen Parts

To support this, a few shared items has been added:

* A customizable `DeleteItemsButton` which sits below lists when multi-select is active.
* A `SelectItemsInterface` that provides a streamlined way of adding select, clear, and select all functionality to lists.

## Screenshots
<img width="896" height="678" alt="image" src="https://github.com/user-attachments/assets/6ea5c7de-ef4c-40df-a044-789a11585e05" />
<img width="896" height="678" alt="image" src="https://github.com/user-attachments/assets/5eb981c6-0691-4b0f-9469-54f83abfd660" />
<img width="896" height="678" alt="image" src="https://github.com/user-attachments/assets/8e75a844-1375-4dd3-8073-a4c38860d0bb" />
<img width="896" height="678" alt="image" src="https://github.com/user-attachments/assets/ae7667f5-a1f7-47ef-9990-7c786973bd51" />
<img width="896" height="678" alt="image" src="https://github.com/user-attachments/assets/d39efe21-9157-498a-9869-87b58a1c4fe7" />
<img width="896" height="678" alt="image" src="https://github.com/user-attachments/assets/0b6690c5-7d33-4236-919e-8ee6412a3e4f" />


