### PR TITLE
Add padding to settings chips

### DIFF
--- a/lib/screens/settings/common.dart
+++ b/lib/screens/settings/common.dart
@@ -241,7 +241,7 @@ class SettingChips extends StatelessWidget {
       title: title,
       children: [
         Padding(
-            padding: const EdgeInsets.fromLTRB(8, 4, 8, 8),
+            padding: const EdgeInsets.fromLTRB(8, 8, 8, 8),
             child: Wrap(
               spacing: 10,
               runSpacing: 10,


### PR DESCRIPTION
Windows Before:

<img width="1266" height="713" alt="image" src="https://github.com/user-attachments/assets/0a446505-067f-4606-8978-907d2a303c6d" />

Windows After:

<img width="1064" height="713" alt="image" src="https://github.com/user-attachments/assets/ae3529b9-5fec-45ee-bf6f-56b2fe615e8a" />

iOS Before:

<img width="1660" height="1376" alt="image" src="https://github.com/user-attachments/assets/e13aa701-f758-43b0-9877-84835eac232c" />

iOS After:
<img width="958" height="781" alt="Screenshot 2026-03-19 at 10 03 36" src="https://github.com/user-attachments/assets/a8f3ee62-7560-44fa-a44b-76883fd398d6" />




