### PR TITLE
Implemented a more straightforward delete

### DIFF
--- a/lib/screens/projects/components/menu_drawer.dart
+++ b/lib/screens/projects/components/menu_drawer.dart
@@ -146,34 +146,44 @@ class ProjectMenuDrawerState extends ConsumerState<ProjectMenuDrawer> {
             style: TextStyle(color: Theme.of(context).colorScheme.error),
           ),
           onTap: () async {
+            final confirmationCode = projectUuid.length >= 5
+                ? projectUuid.substring(0, 5)
+                : projectUuid;
             return showDeleteAlertOnMenu(
                 context: context,
                 title: 'Delete project?',
-                deletePrompt: 'You will delete the project and all its data',
+                deletePrompt:
+                    'You will delete this project and its related data. This cannot be undone.',
+                requiredConfirmationText: confirmationCode,
                 onDelete: () async {
                   try {
-                    await ProjectServices(ref: ref).deleteProject(projectUuid);
+                    final message = await ProjectServices(ref: ref)
+                        .deleteProjectAndData(projectUuid);
                     if (context.mounted) {
+                      Navigator.pop(context);
                       Navigator.pushReplacement(
                         context,
                         MaterialPageRoute(builder: (context) => const Home()),
                       );
+                      if (message != null) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text(message)),
+                        );
+                      }
                     }
                   } catch (e) {
                     if (context.mounted) {
                       Navigator.pop(context);
+                      final errorMessage = e is ProjectDeletionFailure
+                          ? e.toUserMessage()
+                          : e.toString();
                       showDialog(
                           context: context,
                           builder: (context) => AlertDialog(
                                 title: const Text(
                                   'Error',
                                 ),
-                                content: Text(
-                                  e.toString().contains('FOREIGN KEY')
-                                      ? 'Cannot delete project with records.\n'
-                                          'Delete all records first'
-                                      : e.toString(),
-                                ),
+                                content: Text(errorMessage),
                               ));
                     }
                   }

--- a/lib/screens/shared/forms.dart
+++ b/lib/screens/shared/forms.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
@@ -324,7 +326,8 @@ void showDeleteAlertOnMenu({
   required BuildContext context,
   required String deletePrompt,
   required String title,
-  required VoidCallback onDelete,
+  required FutureOr<void> Function() onDelete,
+  String? requiredConfirmationText,
 }) {
   Future.delayed(
     const Duration(milliseconds: 0),
@@ -337,6 +340,7 @@ void showDeleteAlertOnMenu({
               deletePrompt: deletePrompt,
               title: title,
               onDelete: onDelete,
+              requiredConfirmationText: requiredConfirmationText,
             );
           },
         );
@@ -345,39 +349,108 @@ void showDeleteAlertOnMenu({
   );
 }
 
-class DeleteAlerts extends ConsumerWidget {
+class DeleteAlerts extends ConsumerStatefulWidget {
   const DeleteAlerts({
     super.key,
     required this.title,
     required this.deletePrompt,
     required this.onDelete,
+    this.requiredConfirmationText,
   });
 
   final String title;
   final String deletePrompt;
-  final VoidCallback onDelete;
+  final FutureOr<void> Function() onDelete;
+  final String? requiredConfirmationText;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DeleteAlerts> createState() => _DeleteAlertsState();
+}
+
+class _DeleteAlertsState extends ConsumerState<DeleteAlerts> {
+  late final TextEditingController _confirmationController;
+  bool _isDeleting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _confirmationController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _confirmationController.dispose();
+    super.dispose();
+  }
+
+  bool get _isDeleteEnabled {
+    final requiredConfirmation = widget.requiredConfirmationText;
+    if (requiredConfirmation == null) {
+      return true;
+    }
+    return _confirmationController.text == requiredConfirmation;
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text(title),
-      content: Text(
-        deletePrompt,
-        textAlign: TextAlign.center,
+      title: Text(widget.title),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            widget.deletePrompt,
+            textAlign: TextAlign.center,
+          ),
+          if (widget.requiredConfirmationText != null) ...[
+            const SizedBox(height: 16),
+            Text(
+              'Type `${widget.requiredConfirmationText}` to enable delete',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: _confirmationController,
+              autofocus: true,
+              onChanged: (_) => setState(() {}),
+              enabled: !_isDeleting,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                isDense: true,
+                hintText: 'Enter confirmation text',
+              ),
+            ),
+          ],
+        ],
       ),
       actions: [
         TextButton(
-          onPressed: () {
-            Navigator.of(context).pop();
-          },
+          onPressed: _isDeleting
+              ? null
+              : () {
+                  Navigator.of(context).pop();
+                },
           child: const Text('Cancel'),
         ),
         TextButton(
-          onPressed: () {
-            onDelete();
-          },
-          child: Text('Delete',
-              style: TextStyle(color: Theme.of(context).colorScheme.error)),
+          style: TextButton.styleFrom(
+            foregroundColor: Theme.of(context).colorScheme.error,
+            disabledForegroundColor:
+                Theme.of(context).colorScheme.onSurface.withAlpha(160),
+          ),
+          onPressed: _isDeleteEnabled && !_isDeleting
+              ? () async {
+                  setState(() => _isDeleting = true);
+                  try {
+                    await widget.onDelete();
+                  } finally {
+                    if (mounted) {
+                      setState(() => _isDeleting = false);
+                    }
+                  }
+                }
+              : null,
+          child: const Text('Delete'),
         ),
       ],
     );

--- a/lib/screens/sites/components/menu_bar.dart
+++ b/lib/screens/sites/components/menu_bar.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
 import 'package:nahpu/screens/sites/site_view.dart';
+import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/site_services.dart';
 
 Future<void> createNewSite(BuildContext context, WidgetRef ref) {
@@ -165,13 +166,14 @@ class SiteMenuState extends ConsumerState<SiteMenu> {
   }
 
   void _deleteAllSites() {
+    final projectUuid = ref.read(projectUuidProvider);
     showDeleteAlertOnMenu(
         context: context,
         title: 'Delete all sites?',
         deletePrompt: 'You will delete all site records',
         onDelete: () async {
           try {
-            await SiteServices(ref: ref).deleteAllSites();
+            await SiteServices(ref: ref).deleteAllSites(projectUuid);
             if (context.mounted) {
               _popMenu();
             }

--- a/lib/screens/specimens/shared/menu_bar.dart
+++ b/lib/screens/specimens/shared/menu_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
 import 'package:nahpu/screens/specimens/specimen_view.dart';
+import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/specimen_services.dart';
 
 Future<void> createNewSpecimens(BuildContext context, WidgetRef ref) async {
@@ -186,6 +187,7 @@ class SpecimenMenuState extends ConsumerState<SpecimenMenu> {
   }
 
   void _deleteAllSpecimens() {
+    final projectUuid = ref.read(projectUuidProvider);
     showDeleteAlertOnMenu(
         context: context,
         title: 'Delete all specimens?',
@@ -193,7 +195,7 @@ class SpecimenMenuState extends ConsumerState<SpecimenMenu> {
             ', measurements, and specimen parts',
         onDelete: () async {
           try {
-            await SpecimenServices(ref: ref).deleteAllSpecimens();
+            await SpecimenServices(ref: ref).deleteAllSpecimens(projectUuid);
             if (context.mounted) {
               _pop();
             }

--- a/lib/services/collevent_services.dart
+++ b/lib/services/collevent_services.dart
@@ -150,7 +150,8 @@ class CollEventServices extends AppServices {
 
   Future<void> deleteAllCollEvents(String projectUuid) async {
     try {
-      List<CollEventData> collEvents = await getAllCollEvents();
+      List<CollEventData> collEvents =
+          await CollEventQuery(dbAccess).getAllCollEvents(projectUuid);
       for (CollEventData collEvent in collEvents) {
         await WeatherDataQuery(dbAccess).deleteWeatherData(collEvent.id);
         await CollPersonnelQuery(dbAccess)

--- a/lib/services/database/media_queries.dart
+++ b/lib/services/database/media_queries.dart
@@ -42,4 +42,23 @@ class MediaDbQuery extends DatabaseAccessor<Database> with _$MediaDbQueryMixin {
   Future<void> deleteMedia(int id) {
     return (delete(media)..where((t) => t.primaryId.equals(id))).go();
   }
+
+  Future<void> deleteMediaByProject(String projectUuid) {
+    return (delete(media)..where((t) => t.projectUuid.equals(projectUuid)))
+        .go();
+  }
+
+  Future<bool> isMediaReferencedByTaxonomy(int mediaId) async {
+    final taxonomyRow = await (select(taxonomy)
+          ..where((t) => t.mediaId.equals(mediaId))
+          ..limit(1))
+        .getSingleOrNull();
+    return taxonomyRow != null;
+  }
+
+  Future<void> detachMediaFromProject(int mediaId) {
+    return (update(media)..where((t) => t.primaryId.equals(mediaId))).write(
+      const MediaCompanion(projectUuid: Value(null)),
+    );
+  }
 }

--- a/lib/services/database/personnel_queries.dart
+++ b/lib/services/database/personnel_queries.dart
@@ -18,6 +18,13 @@ class PersonnelQuery extends DatabaseAccessor<Database>
     return await select(personnelList).get();
   }
 
+  Future<List<PersonnelListData>> getProjectPersonnelLinks(
+      String projectUuid) async {
+    return (select(personnelList)
+          ..where((t) => t.projectUuid.equals(projectUuid)))
+        .get();
+  }
+
   Future<bool> isImageUsed(String baseName) async {
     final PersonnelData? personnelList = await (select(personnel)
           ..where((tbl) => tbl.photoPath.equals(baseName))
@@ -122,6 +129,12 @@ class PersonnelQuery extends DatabaseAccessor<Database>
           ..where((t) =>
               t.projectUuid.equals(projectUuid) &
               t.personnelUuid.equals(personnelUuid)))
+        .go();
+  }
+
+  Future<void> deleteAllProjectPersonnel({required String projectUuid}) {
+    return (delete(personnelList)
+          ..where((t) => t.projectUuid.equals(projectUuid)))
         .go();
   }
 

--- a/lib/services/narrative_services.dart
+++ b/lib/services/narrative_services.dart
@@ -43,8 +43,9 @@ class NarrativeServices extends AppServices {
         try {
           // Check whether the 'time' column already exists to avoid duplicate
           // ALTER TABLE statements from concurrent callers.
-          final List<db.QueryRow> rows =
-              await dbAccess.customSelect("PRAGMA table_info('narrative')").get();
+          final List<db.QueryRow> rows = await dbAccess
+              .customSelect("PRAGMA table_info('narrative')")
+              .get();
           bool hasTime = false;
           for (final row in rows) {
             try {
@@ -59,7 +60,8 @@ class NarrativeServices extends AppServices {
           }
 
           if (!hasTime) {
-            await dbAccess.customStatement('ALTER TABLE narrative ADD COLUMN time TEXT');
+            await dbAccess
+                .customStatement('ALTER TABLE narrative ADD COLUMN time TEXT');
           }
 
           await NarrativeQuery(dbAccess).updateNarrativeEntry(id, entries);
@@ -139,7 +141,7 @@ class NarrativeServices extends AppServices {
     for (NarrativeData narrative in narratives) {
       await deleteAllNarrativeMedia(narrative.id);
     }
-    NarrativeQuery(dbAccess).deleteAllNarrative(projectUuid);
+    await NarrativeQuery(dbAccess).deleteAllNarrative(projectUuid);
     invalidateNarrative();
   }
 

--- a/lib/services/project_services.dart
+++ b/lib/services/project_services.dart
@@ -1,13 +1,55 @@
+import 'package:nahpu/services/collevent_services.dart';
+import 'package:nahpu/services/database/collevent_queries.dart';
+import 'package:nahpu/services/database/media_queries.dart';
+import 'package:nahpu/services/database/narrative_queries.dart';
+import 'package:nahpu/services/database/personnel_queries.dart';
 import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/providers/validation.dart';
 import 'package:nahpu/services/database/database.dart';
 import 'package:nahpu/services/database/project_queries.dart';
+import 'package:nahpu/services/database/site_queries.dart';
+import 'package:nahpu/services/database/specimen_queries.dart';
 import 'package:nahpu/services/io_services.dart';
+import 'package:nahpu/services/narrative_services.dart';
+import 'package:nahpu/services/site_services.dart';
+import 'package:nahpu/services/specimen_services.dart';
 import 'package:uuid/uuid.dart';
 
 String get uuid => const Uuid().v4();
 
 get defaultCatalog => 'general-mammals';
+
+class ProjectDeletionFailure implements Exception {
+  ProjectDeletionFailure({
+    required this.phase,
+    required this.diagnosticSummary,
+    this.cause,
+  });
+
+  final String phase;
+  final String diagnosticSummary;
+  final Object? cause;
+
+  String toUserMessage() {
+    final header = 'Project deletion failed while deleting $phase.';
+    if (diagnosticSummary.isEmpty) {
+      return '$header Some related data still references this project and could not be safely deleted.';
+    }
+    return '$header Remaining related data: $diagnosticSummary.';
+  }
+
+  @override
+  String toString() {
+    return toUserMessage();
+  }
+}
+
+class _ProjectDeletionPhaseFailure implements Exception {
+  _ProjectDeletionPhaseFailure(this.phase, this.cause);
+
+  final String phase;
+  final Object cause;
+}
 
 class ProjectServices extends AppServices {
   const ProjectServices({required super.ref});
@@ -48,6 +90,134 @@ class ProjectServices extends AppServices {
   Future<void> deleteProject(String uuid) async {
     await ProjectQuery(dbAccess).deleteProject(uuid);
     ref.invalidate(projectListProvider);
+  }
+
+  Future<String?> deleteProjectAndData(String projectUuid) async {
+    try {
+      await dbAccess.transaction(() async {
+        await _runDeletionPhase('specimen records',
+            () => SpecimenServices(ref: ref).deleteAllSpecimens(projectUuid));
+        await _runDeletionPhase('collecting events',
+            () => CollEventServices(ref: ref).deleteAllCollEvents(projectUuid));
+        await _runDeletionPhase('narrative entries',
+            () => NarrativeServices(ref: ref).deleteAllNarrative(projectUuid));
+        await _runDeletionPhase(
+            'site records', () => SiteServices(ref: ref).deleteAllSites(projectUuid));
+        await _runDeletionPhase(
+            'project personnel links',
+            () => PersonnelQuery(dbAccess)
+                .deleteAllProjectPersonnel(projectUuid: projectUuid));
+        await _runDeletionPhase(
+            'project media', () => _cleanupProjectMedia(projectUuid));
+        await _runDeletionPhase(
+            'project record', () => ProjectQuery(dbAccess).deleteProject(projectUuid));
+      });
+    } catch (e) {
+      final phase =
+          e is _ProjectDeletionPhaseFailure ? e.phase : 'project data';
+      String diagnostics = '';
+      try {
+        diagnostics = await _collectDeletionDiagnostics(projectUuid);
+      } catch (_) {
+        diagnostics = '';
+      }
+      throw ProjectDeletionFailure(
+        phase: phase,
+        diagnosticSummary: diagnostics,
+        cause: e is _ProjectDeletionPhaseFailure ? e.cause : e,
+      );
+    }
+
+    String? cleanupWarning;
+    final projectDir =
+        await FileServices(ref: ref).getProjectDirByUUID(projectUuid);
+    try {
+      if (projectDir.existsSync()) {
+        await projectDir.delete(recursive: true);
+      }
+    } catch (e) {
+      cleanupWarning = 'Project data deleted, but file cleanup failed: $e';
+    }
+
+    invalidateProject();
+    return cleanupWarning;
+  }
+
+  Future<void> _runDeletionPhase(
+      String phase, Future<void> Function() action) async {
+    try {
+      await action();
+    } catch (e) {
+      throw _ProjectDeletionPhaseFailure(phase, e);
+    }
+  }
+
+  Future<String> _collectDeletionDiagnostics(String projectUuid) async {
+    final parts = <String>[];
+
+    final specimenCount =
+        (await SpecimenQuery(dbAccess).getAllSpecimens(projectUuid)).length;
+    if (specimenCount > 0) {
+      parts.add(_formatCount(specimenCount, 'specimen record'));
+    }
+
+    final collEventCount =
+        (await CollEventQuery(dbAccess).getAllCollEvents(projectUuid)).length;
+    if (collEventCount > 0) {
+      parts.add(_formatCount(collEventCount, 'collecting event'));
+    }
+
+    final narrativeCount =
+        (await NarrativeQuery(dbAccess).getAllNarrative(projectUuid)).length;
+    if (narrativeCount > 0) {
+      parts.add(_formatCount(narrativeCount, 'narrative entry'));
+    }
+
+    final siteCount = (await SiteQuery(dbAccess).getAllSites(projectUuid)).length;
+    if (siteCount > 0) {
+      parts.add(_formatCount(siteCount, 'site record'));
+    }
+
+    final projectPersonnelCount =
+        (await PersonnelQuery(dbAccess).getProjectPersonnelLinks(projectUuid))
+            .length;
+    if (projectPersonnelCount > 0) {
+      parts.add(_formatCount(projectPersonnelCount, 'project personnel link'));
+    }
+
+    final mediaCount =
+        (await MediaDbQuery(dbAccess).getMediaByProject(projectUuid)).length;
+    if (mediaCount > 0) {
+      parts.add(_formatCount(mediaCount, 'project media item'));
+    }
+
+    try {
+      await ProjectQuery(dbAccess).getProjectByUuid(projectUuid);
+      parts.add('project record');
+    } catch (_) {
+      // No-op, project record does not exist.
+    }
+
+    return parts.join(', ');
+  }
+
+  String _formatCount(int count, String singular) {
+    final suffix = count == 1 ? singular : '${singular}s';
+    return '$count $suffix';
+  }
+
+  Future<void> _cleanupProjectMedia(String projectUuid) async {
+    final mediaQuery = MediaDbQuery(dbAccess);
+    final projectMedia = await mediaQuery.getMediaByProject(projectUuid);
+    for (final mediaRow in projectMedia) {
+      final hasSharedReference =
+          await mediaQuery.isMediaReferencedByTaxonomy(mediaRow.primaryId);
+      if (hasSharedReference) {
+        await mediaQuery.detachMediaFromProject(mediaRow.primaryId);
+      } else {
+        await mediaQuery.deleteMedia(mediaRow.primaryId);
+      }
+    }
   }
 
   void invalidateProject() {

--- a/lib/services/site_services.dart
+++ b/lib/services/site_services.dart
@@ -110,15 +110,15 @@ class SiteServices extends AppServices {
     invalidateSite();
   }
 
-  Future<void> deleteAllSites() async {
+  Future<void> deleteAllSites(String projectUuid) async {
     try {
-      List<SiteData> sites = await getAllSites();
+      List<SiteData> sites = await SiteQuery(dbAccess).getAllSites(projectUuid);
 
       for (SiteData site in sites) {
         await CoordinateServices(ref: ref).deleteCoordinateBySiteID(site.id);
         await SiteQuery(dbAccess).deleteAllSiteMedias(site.id);
       }
-      await SiteQuery(dbAccess).deleteAllSites(currentProjectUuid);
+      await SiteQuery(dbAccess).deleteAllSites(projectUuid);
       invalidateSite();
     } catch (e) {
       rethrow;

--- a/lib/services/specimen_services.dart
+++ b/lib/services/specimen_services.dart
@@ -327,10 +327,13 @@ class SpecimenServices extends AppServices {
     invalidateSpecimenList();
   }
 
-  Future<void> deleteAllSpecimens() async {
-    List<SpecimenData> specimenList = await getSpecimenList();
+  Future<void> deleteAllSpecimens(String projectUuid) async {
+    List<SpecimenData> specimenList =
+        await SpecimenQuery(dbAccess).getAllSpecimens(projectUuid);
     for (var specimen in specimenList) {
       await deleteAllSpecimenParts(specimen.uuid);
+      await AssociatedDataQuery(dbAccess)
+          .deleteAllAssociatedData(specimen.uuid);
       await SpecimenQuery(dbAccess).deleteAllSpecimenMedias(specimen.uuid);
       CatalogFmt catalogFmt = matchTaxonGroupToCatFmt(specimen.taxonGroup);
       switch (catalogFmt) {
@@ -345,7 +348,7 @@ class SpecimenServices extends AppServices {
           break;
       }
     }
-    await SpecimenQuery(dbAccess).deleteAllSpecimens(currentProjectUuid);
+    await SpecimenQuery(dbAccess).deleteAllSpecimens(projectUuid);
     invalidateSpecimenList();
   }
 

--- a/test/delete_alert_test.dart
+++ b/test/delete_alert_test.dart
@@ -1,0 +1,181 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nahpu/screens/shared/forms.dart';
+import 'package:nahpu/services/project_services.dart';
+
+void main() {
+  testWidgets('delete button requires exact confirmation text', (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: DeleteAlerts(
+              title: 'Delete project?',
+              deletePrompt: 'Delete prompt',
+              requiredConfirmationText: 'abcde',
+              onDelete: _noOpDelete,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    TextButton deleteButton =
+        tester.widget<TextButton>(find.widgetWithText(TextButton, 'Delete'));
+    expect(deleteButton.onPressed, isNull);
+
+    await tester.enterText(find.byType(TextField), 'abcd');
+    await tester.pump();
+    deleteButton =
+        tester.widget<TextButton>(find.widgetWithText(TextButton, 'Delete'));
+    expect(deleteButton.onPressed, isNull);
+
+    await tester.enterText(find.byType(TextField), 'abcde');
+    await tester.pump();
+    deleteButton =
+        tester.widget<TextButton>(find.widgetWithText(TextButton, 'Delete'));
+    expect(deleteButton.onPressed, isNotNull);
+  });
+
+  testWidgets('delete button uses disabled visual state before confirmation',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: DeleteAlerts(
+              title: 'Delete project?',
+              deletePrompt: 'Delete prompt',
+              requiredConfirmationText: 'abcde',
+              onDelete: _noOpDelete,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    TextButton deleteButton =
+        tester.widget<TextButton>(find.widgetWithText(TextButton, 'Delete'));
+    final disabledColor = deleteButton.style?.foregroundColor
+        ?.resolve({WidgetState.disabled});
+    expect(disabledColor, isNotNull);
+
+    await tester.enterText(find.byType(TextField), 'abcde');
+    await tester.pump();
+
+    deleteButton =
+        tester.widget<TextButton>(find.widgetWithText(TextButton, 'Delete'));
+    final enabledColor =
+        deleteButton.style?.foregroundColor?.resolve(<WidgetState>{});
+    expect(enabledColor, isNotNull);
+    expect(enabledColor, isNot(equals(disabledColor)));
+  });
+
+  testWidgets('dialog controls are disabled while delete is running',
+      (tester) async {
+    final completer = Completer<void>();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Scaffold(
+            body: DeleteAlerts(
+              title: 'Delete project?',
+              deletePrompt: 'Delete prompt',
+              requiredConfirmationText: 'abcde',
+              onDelete: () => completer.future,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'abcde');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(TextButton, 'Delete'));
+    await tester.pump();
+
+    final TextField textField =
+        tester.widget<TextField>(find.byType(TextField));
+    expect(textField.enabled, isFalse);
+
+    final TextButton cancelButton =
+        tester.widget<TextButton>(find.widgetWithText(TextButton, 'Cancel'));
+    expect(cancelButton.onPressed, isNull);
+
+    completer.complete();
+    await tester.pump();
+  });
+
+  testWidgets('shows formatted phase failure message in error dialog',
+      (tester) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) {
+              return Scaffold(
+                body: Center(
+                  child: TextButton(
+                    onPressed: () {
+                      showDeleteAlertOnMenu(
+                        context: context,
+                        title: 'Delete project?',
+                        deletePrompt: 'Delete prompt',
+                        requiredConfirmationText: 'abcde',
+                        onDelete: () async {
+                          try {
+                            throw ProjectDeletionFailure(
+                              phase: 'collecting events',
+                              diagnosticSummary:
+                                  '3 specimen records, 1 collecting event',
+                            );
+                          } catch (e) {
+                            if (!context.mounted) return;
+                            Navigator.pop(context);
+                            final errorMessage = e is ProjectDeletionFailure
+                                ? e.toUserMessage()
+                                : e.toString();
+                            await showDialog(
+                              context: context,
+                              builder: (context) => AlertDialog(
+                                title: const Text('Error'),
+                                content: Text(errorMessage),
+                              ),
+                            );
+                          }
+                        },
+                      );
+                    },
+                    child: const Text('Open delete dialog'),
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open delete dialog'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), 'abcde');
+    await tester.pump();
+    await tester.tap(find.widgetWithText(TextButton, 'Delete'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Error'), findsOneWidget);
+    expect(
+      find.text(
+        'Project deletion failed while deleting collecting events. Remaining related data: 3 specimen records, 1 collecting event.',
+      ),
+      findsOneWidget,
+    );
+  });
+}
+
+Future<void> _noOpDelete() async {}

--- a/test/project_delete_test.dart
+++ b/test/project_delete_test.dart
@@ -1,0 +1,238 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart' show DatabaseConnection, Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nahpu/services/database/database.dart';
+import 'package:nahpu/services/database/media_queries.dart';
+import 'package:nahpu/services/database/narrative_queries.dart';
+import 'package:nahpu/services/database/personnel_queries.dart';
+import 'package:nahpu/services/database/project_queries.dart';
+import 'package:nahpu/services/database/specimen_queries.dart';
+import 'package:nahpu/services/project_services.dart';
+import 'package:nahpu/services/providers/database.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+  final tempAppDir =
+      Directory.systemTemp.createTempSync('nahpu-project-delete-test');
+
+  late Database db;
+  late WidgetRef ref;
+
+  setUpAll(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, (methodCall) async {
+      if (methodCall.method == 'getApplicationDocumentsDirectory') {
+        return tempAppDir.path;
+      }
+      return tempAppDir.path;
+    });
+  });
+
+  tearDownAll(() async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathProviderChannel, null);
+    if (tempAppDir.existsSync()) {
+      await tempAppDir.delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  testWidgets('deleteProjectAndData removes all dependent records',
+      (tester) async {
+    ref = await _buildRef(tester, db);
+
+    const projectUuid = 'proj-delete-1';
+    await _seedProjectWithLinkedData(db, projectUuid);
+
+    final result = await tester.runAsync(
+      () => ProjectServices(ref: ref).deleteProjectAndData(projectUuid),
+    );
+
+    expect(result, isNull);
+    expect(await ProjectQuery(db).getAllProjects(), isEmpty);
+    expect(await SpecimenQuery(db).getAllSpecimens(projectUuid), isEmpty);
+    expect(await NarrativeQuery(db).getAllNarrative(projectUuid), isEmpty);
+    expect(await MediaDbQuery(db).getMediaByProject(projectUuid), isEmpty);
+    expect(await PersonnelQuery(db).getProjectPersonnelLinks(projectUuid),
+        isEmpty);
+  });
+
+  testWidgets('associatedData no longer blocks project deletion',
+      (tester) async {
+    ref = await _buildRef(tester, db);
+
+    const projectUuid = 'proj-delete-2';
+    await _seedProjectWithLinkedData(db, projectUuid);
+
+    final result = await tester.runAsync(
+      () => ProjectServices(ref: ref).deleteProjectAndData(projectUuid),
+    );
+
+    expect(result, isNull);
+    final associatedRows = await AssociatedDataQuery(db)
+        .getAllAssociatedData('specimen-$projectUuid');
+    expect(associatedRows, isEmpty);
+    expect(await ProjectQuery(db).getAllProjects(), isEmpty);
+  });
+
+  testWidgets('former blockers are deleted instead of blocking',
+      (tester) async {
+    ref = await _buildRef(tester, db);
+
+    const projectUuid = 'proj-delete-3';
+    await _seedProjectWithLinkedData(db, projectUuid);
+
+    final result = await tester.runAsync(
+      () => ProjectServices(ref: ref).deleteProjectAndData(projectUuid),
+    );
+
+    expect(result, isNull);
+    expect(await NarrativeQuery(db).getAllNarrative(projectUuid), isEmpty);
+    expect(await MediaDbQuery(db).getMediaByProject(projectUuid), isEmpty);
+    expect(await PersonnelQuery(db).getProjectPersonnelLinks(projectUuid),
+        isEmpty);
+  });
+
+  testWidgets('taxonomy-linked media is preserved and detached from project',
+      (tester) async {
+    ref = await _buildRef(tester, db);
+
+    const projectUuid = 'proj-delete-4';
+    final seeded = await _seedProjectWithLinkedData(db, projectUuid,
+        includeTaxonomyLinkedMedia: true);
+
+    final result = await tester.runAsync(
+      () => ProjectServices(ref: ref).deleteProjectAndData(projectUuid),
+    );
+
+    expect(result, isNull);
+    expect(await ProjectQuery(db).getAllProjects(), isEmpty);
+
+    final taxonomyRow = await (db.select(db.taxonomy)
+          ..where((t) => t.id.equals(seeded.taxonomyId!)))
+        .getSingleOrNull();
+    expect(taxonomyRow, isNotNull);
+
+    final preservedMedia =
+        await MediaDbQuery(db).getMedia(seeded.sharedMediaId!);
+    expect(preservedMedia.projectUuid, isNull);
+  });
+}
+
+Future<WidgetRef> _buildRef(WidgetTester tester, Database db) async {
+  WidgetRef? widgetRef;
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [databaseProvider.overrideWithValue(db)],
+      child: MaterialApp(
+        home: Consumer(
+          builder: (context, ref, child) {
+            widgetRef = ref;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    ),
+  );
+
+  await tester.pump();
+  return widgetRef!;
+}
+
+Future<({int? sharedMediaId, int? taxonomyId})> _seedProjectWithLinkedData(
+  Database db,
+  String projectUuid, {
+  bool includeTaxonomyLinkedMedia = false,
+}) async {
+  await ProjectQuery(db).createProject(ProjectCompanion(
+    uuid: Value(projectUuid),
+    name: Value('Project $projectUuid'),
+  ));
+
+  await PersonnelQuery(db).createPersonnel(PersonnelCompanion(
+    uuid: Value('person-$projectUuid'),
+    name: const Value('Test Person'),
+  ));
+
+  await PersonnelQuery(db).createProjectPersonnelEntry(PersonnelListCompanion(
+    projectUuid: Value(projectUuid),
+    personnelUuid: Value('person-$projectUuid'),
+  ));
+
+  final siteId = await db.into(db.site).insert(SiteCompanion(
+        projectUuid: Value(projectUuid),
+      ));
+
+  final eventId = await db.into(db.collEvent).insert(CollEventCompanion(
+        projectUuid: Value(projectUuid),
+        siteID: Value(siteId),
+      ));
+
+  await db.into(db.weather).insert(WeatherCompanion(eventID: Value(eventId)));
+
+  final specimenUuid = 'specimen-$projectUuid';
+  await SpecimenQuery(db).createSpecimen(SpecimenCompanion(
+    uuid: Value(specimenUuid),
+    projectUuid: Value(projectUuid),
+    taxonGroup: const Value('General Mammals'),
+    collEventID: Value(eventId),
+  ));
+
+  await AssociatedDataQuery(db).createSpecimenDataAssociation(
+    AssociatedDataCompanion(
+      specimenUuid: Value(specimenUuid),
+      name: const Value('Sound file'),
+      url: const Value('recording.wav'),
+    ),
+  );
+
+  final mediaId = await MediaDbQuery(db).createMedia(MediaCompanion(
+    projectUuid: Value(projectUuid),
+    fileName: const Value('photo.jpg'),
+    category: const Value('narrative'),
+  ));
+
+  final narrativeId = await NarrativeQuery(db).createNarrative(
+    NarrativeCompanion(
+      projectUuid: Value(projectUuid),
+      siteID: Value(siteId),
+      narrative: const Value('Narrative content'),
+    ),
+  );
+
+  await NarrativeQuery(db).createNarrativeMedia(NarrativeMediaCompanion(
+    narrativeId: Value(narrativeId),
+    mediaId: Value(mediaId),
+  ));
+
+  if (!includeTaxonomyLinkedMedia) {
+    return (sharedMediaId: null, taxonomyId: null);
+  }
+
+  final taxonomyMediaId = await MediaDbQuery(db).createMedia(MediaCompanion(
+    projectUuid: Value(projectUuid),
+    fileName: const Value('taxon-photo.jpg'),
+    category: const Value('taxonomy'),
+  ));
+
+  final taxonomyId = await db.into(db.taxonomy).insert(TaxonomyCompanion(
+        mediaId: Value(taxonomyMediaId),
+      ));
+
+  return (sharedMediaId: taxonomyMediaId, taxonomyId: taxonomyId);
+}

--- a/test/project_deletion_failure_test.dart
+++ b/test/project_deletion_failure_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nahpu/services/project_services.dart';
+
+void main() {
+  test('ProjectDeletionFailure message includes phase and diagnostics', () {
+    final failure = ProjectDeletionFailure(
+      phase: 'collecting events',
+      diagnosticSummary: '3 specimen records, 1 collecting event',
+    );
+
+    expect(
+      failure.toUserMessage(),
+      'Project deletion failed while deleting collecting events. Remaining related data: 3 specimen records, 1 collecting event.',
+    );
+    expect(failure.toString(), failure.toUserMessage());
+  });
+
+  test('ProjectDeletionFailure falls back to generic detail', () {
+    final failure = ProjectDeletionFailure(
+      phase: 'project media',
+      diagnosticSummary: '',
+    );
+
+    expect(
+      failure.toUserMessage(),
+      'Project deletion failed while deleting project media. Some related data still references this project and could not be safely deleted.',
+    );
+  });
+}


### PR DESCRIPTION
Updated the UI to allow for deleting everything related to the project (specimens, events, narratives, sites, media owned by the project) when users enter the exact 5-letter project UUID.  Taxonomy and personnel data references to the current project would be deleted, but not the taxonomy and personnel data itself. 

Fixes issue: https://github.com/nahpu/nahpu/issues/115


https://github.com/user-attachments/assets/c13844d0-ecf5-4f20-bd37-dbae3d60fe30

