### PR TITLE
Refactor navbar route transition

### DIFF
--- a/lib/screens/events/components/menu_bar.dart
+++ b/lib/screens/events/components/menu_bar.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:nahpu/screens/events/event_view.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
 import 'package:nahpu/services/collevent_services.dart';
+import 'package:nahpu/services/providers/collevents.dart';
 import 'package:nahpu/services/providers/projects.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -11,13 +11,8 @@ Future<void> createNewCollEvents(BuildContext context, WidgetRef ref) {
 
   return services.createNewCollEvents().then(
     (_) {
-      if (context.mounted) {
-        Navigator.of(context).pushReplacement(
-          MaterialPageRoute(
-            builder: (_) => const CollEventViewer(),
-          ),
-        );
-      }
+      // CollEventViewer stays mounted in ProjectShell; refresh it in place.
+      ref.invalidate(collEventEntryProvider);
     },
   );
 }
@@ -124,9 +119,11 @@ class NarrativeMenuState extends ConsumerState<CollEventMenu> {
           try {
             await CollEventServices(ref: ref)
                 .deleteCollEvent(widget.collEventId!);
-            if (context.mounted) {
-              _navigate();
+            // Close the delete dialog and refresh the list in place.
+            if (mounted) {
+              Navigator.of(context).pop();
             }
+            ref.invalidate(collEventEntryProvider);
           } catch (e) {
             _showError(e.toString());
           }
@@ -135,23 +132,10 @@ class NarrativeMenuState extends ConsumerState<CollEventMenu> {
     }
   }
 
-  void _navigate() {
-    Navigator.of(context).pop();
-    // We need to trigger a rebuild of the CollEventViewer
-    // to update page numbers and the CollEventViewer
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(
-        builder: (_) => const CollEventViewer(),
-      ),
-    );
-  }
-
   Future<void> _duplicateEvent() async {
     try {
       await EventDuplicateService(ref: ref).duplicate(widget.collEventId!);
-      if (context.mounted) {
-        _navigate();
-      }
+      ref.invalidate(collEventEntryProvider);
     } catch (e) {
       _showError(e.toString());
     }

--- a/lib/screens/events/components/menu_bar.dart
+++ b/lib/screens/events/components/menu_bar.dart
@@ -12,8 +12,7 @@ Future<void> createNewCollEvents(BuildContext context, WidgetRef ref) {
 
   return services.createNewCollEvents().then(
     (newId) {
-      // CollEventViewer stays mounted in ProjectShell; refresh it in place
-      // and land on the new event once it appears in the refreshed list.
+      // Refresh the always-mounted viewer in place and land on the new event.
       ref
           .read(pendingRecordJumpProvider(RecordViewer.collEvent).notifier)
           .state = newId;
@@ -124,7 +123,7 @@ class NarrativeMenuState extends ConsumerState<CollEventMenu> {
           try {
             await CollEventServices(ref: ref)
                 .deleteCollEvent(widget.collEventId!);
-            // Close the delete dialog and refresh the list in place.
+            // Close the delete dialog.
             if (mounted) {
               Navigator.of(context).pop();
             }

--- a/lib/screens/events/components/menu_bar.dart
+++ b/lib/screens/events/components/menu_bar.dart
@@ -3,6 +3,7 @@ import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
 import 'package:nahpu/services/collevent_services.dart';
 import 'package:nahpu/services/providers/collevents.dart';
+import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/services/providers/projects.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -10,8 +11,12 @@ Future<void> createNewCollEvents(BuildContext context, WidgetRef ref) {
   CollEventServices services = CollEventServices(ref: ref);
 
   return services.createNewCollEvents().then(
-    (_) {
-      // CollEventViewer stays mounted in ProjectShell; refresh it in place.
+    (newId) {
+      // CollEventViewer stays mounted in ProjectShell; refresh it in place
+      // and land on the new event once it appears in the refreshed list.
+      ref
+          .read(pendingRecordJumpProvider(RecordViewer.collEvent).notifier)
+          .state = newId;
       ref.invalidate(collEventEntryProvider);
     },
   );
@@ -134,7 +139,13 @@ class NarrativeMenuState extends ConsumerState<CollEventMenu> {
 
   Future<void> _duplicateEvent() async {
     try {
-      await EventDuplicateService(ref: ref).duplicate(widget.collEventId!);
+      final newId =
+          await EventDuplicateService(ref: ref).duplicate(widget.collEventId!);
+      if (newId != null) {
+        ref
+            .read(pendingRecordJumpProvider(RecordViewer.collEvent).notifier)
+            .state = newId;
+      }
       ref.invalidate(collEventEntryProvider);
     } catch (e) {
       _showError(e.toString());

--- a/lib/screens/events/event_view.dart
+++ b/lib/screens/events/event_view.dart
@@ -7,6 +7,7 @@ import 'package:nahpu/services/database/database.dart';
 import 'package:nahpu/services/navigation_services.dart';
 import 'package:nahpu/services/types/controllers.dart';
 import 'package:nahpu/services/providers/collevents.dart';
+import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/screens/events/event_form.dart';
 import 'package:nahpu/screens/events/components/menu_bar.dart';
 import 'package:nahpu/screens/shared/common.dart';
@@ -24,6 +25,7 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
   final PageNavigation _pageNav = PageNavigation.init();
   final TextEditingController _searchController = TextEditingController();
   int? _collEvenId;
+  bool _loadedOnce = false;
   bool _isSearching = false;
   final FocusNode _focus = FocusNode();
 
@@ -136,19 +138,52 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
   void _reconcile(List<CollEventData> collEventEntries) {
     if (!mounted) return;
     final count = collEventEntries.length;
+    final landIndex = _landingIndex(collEventEntries);
+    if (landIndex != null) {
+      _pageNav.currentPage = landIndex + 1;
+    }
     final index = _pageNav.clampToCount(count);
     setState(() {
       _isVisible = count >= 2;
       if (count == 0) {
         _collEvenId = null;
-      } else if (_collEvenId == null ||
+      } else if (landIndex != null ||
+          _collEvenId == null ||
           !collEventEntries.any((event) => event.id == _collEvenId)) {
         _collEvenId = collEventEntries[index].id;
       }
     });
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _pageNav.clampController(index);
-    });
+    if (landIndex != null) {
+      _pageNav.openControllerAt(index);
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _pageNav.clampController(index);
+      });
+    }
+  }
+
+  /// One-shot landing target for this refresh: a just-created record once it
+  /// appears in the list, or the last record on this State's first data load
+  /// (the old push-a-fresh-viewer-per-tab flow always landed at the end).
+  int? _landingIndex(List<CollEventData> collEventEntries) {
+    final firstLoad = !_loadedOnce;
+    _loadedOnce = true;
+    final pendingJump =
+        ref.read(pendingRecordJumpProvider(RecordViewer.collEvent));
+    if (pendingJump != null) {
+      final target =
+          collEventEntries.indexWhere((event) => event.id == pendingJump);
+      if (target != -1) {
+        ref
+            .read(pendingRecordJumpProvider(RecordViewer.collEvent).notifier)
+            .state = null;
+        return target;
+      }
+    }
+    if (firstLoad && collEventEntries.isNotEmpty) {
+      return collEventEntries.length - 1;
+    }
+    return null;
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/events/event_view.dart
+++ b/lib/screens/events/event_view.dart
@@ -46,6 +46,9 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
     final services = CollEventServices(ref: ref);
     // Reconcile page/selection bookkeeping outside build (see site_view.dart).
     ref.listen(collEventEntryProvider, (_, next) {
+      // Skip refresh emissions: an in-progress refresh still carries the
+      // previous list (see site_view.dart).
+      if (next.isLoading) return;
       next.whenData(_reconcile);
     });
     return Scaffold(
@@ -153,13 +156,12 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
         _collEvenId = collEventEntries[index].id;
       }
     });
-    if (landIndex != null && !_pageNav.pageController.hasClients) {
-      // First attach: a fresh controller opens the PageView directly on the
-      // target page (initialPage only applies to a newly created position).
+    if (landIndex != null) {
+      // The PageView is keyed by the controller, so this rebuilds it with a
+      // fresh scroll position that starts exactly on the target page — a
+      // jump on the live controller would race the refreshed list's layout.
       _pageNav.openControllerAt(index);
     } else {
-      // Attached PageView: a controller swap would re-attach the existing
-      // scroll position unchanged, so jump after the rebuilt frame instead.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _pageNav.clampController(index);
       });
@@ -218,6 +220,9 @@ class CollEventPages extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
+      // Keyed by controller identity so openControllerAt lands on its page
+      // via a fresh scroll position (see site_view.dart).
+      key: ObjectKey(pageNav.pageController),
       controller: pageNav.pageController,
       itemCount: collEventEntries.length,
       itemBuilder: (context, index) {

--- a/lib/screens/events/event_view.dart
+++ b/lib/screens/events/event_view.dart
@@ -42,6 +42,10 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
   @override
   Widget build(BuildContext context) {
     final services = CollEventServices(ref: ref);
+    // Reconcile page/selection bookkeeping outside build (see site_view.dart).
+    ref.listen(collEventEntryProvider, (_, next) {
+      next.whenData(_reconcile);
+    });
     return Scaffold(
       appBar: AppBar(
         title: const Text("Events"),
@@ -101,35 +105,19 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
           child: ref.watch(collEventEntryProvider).when(
                 data: (collEventEntries) {
                   if (collEventEntries.isEmpty) {
-                    setState(() {
-                      _isVisible = false;
-                      _collEvenId = null;
-                    });
-
                     return EmptyCollEvent(isButtonVisible: !_isSearching);
-                  } else {
-                    int collEventSize = collEventEntries.length;
-                    setState(() {
-                      if (collEventSize >= 2) {
-                        _isVisible = true;
-                      } else {
-                        _isVisible = false;
-                      }
-                      _pageNav.pageCounts = collEventSize;
-                      _pageNav.updatePageController();
-                    });
-                    return CollEventPages(
-                      collEventEntries: collEventEntries,
-                      pageNav: _pageNav,
-                      isNavButtonVisible: _isVisible,
-                      onPageChanged: (index) {
-                        setState(() {
-                          _collEvenId = collEventEntries[index].id;
-                          _updatePageNav(index);
-                        });
-                      },
-                    );
                   }
+                  return CollEventPages(
+                    collEventEntries: collEventEntries,
+                    pageNav: _pageNav,
+                    isNavButtonVisible: _isVisible,
+                    onPageChanged: (index) {
+                      setState(() {
+                        _collEvenId = collEventEntries[index].id;
+                        _updatePageNav(index);
+                      });
+                    },
+                  );
                 },
                 loading: () => const CommonProgressIndicator(),
                 error: (error, stack) => Text(error.toString()),
@@ -143,6 +131,24 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
         ),
       ),
     );
+  }
+
+  void _reconcile(List<CollEventData> collEventEntries) {
+    if (!mounted) return;
+    final count = collEventEntries.length;
+    final index = _pageNav.clampToCount(count);
+    setState(() {
+      _isVisible = count >= 2;
+      if (count == 0) {
+        _collEvenId = null;
+      } else if (_collEvenId != null &&
+          !collEventEntries.any((event) => event.id == _collEvenId)) {
+        _collEvenId = collEventEntries[index].id;
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _pageNav.clampController(index);
+    });
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/events/event_view.dart
+++ b/lib/screens/events/event_view.dart
@@ -153,9 +153,13 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
         _collEvenId = collEventEntries[index].id;
       }
     });
-    if (landIndex != null) {
+    if (landIndex != null && !_pageNav.pageController.hasClients) {
+      // First attach: a fresh controller opens the PageView directly on the
+      // target page (initialPage only applies to a newly created position).
       _pageNav.openControllerAt(index);
     } else {
+      // Attached PageView: a controller swap would re-attach the existing
+      // scroll position unchanged, so jump after the rebuilt frame instead.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _pageNav.clampController(index);
       });

--- a/lib/screens/events/event_view.dart
+++ b/lib/screens/events/event_view.dart
@@ -148,7 +148,6 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
           pageNav: _pageNav,
         ),
       ),
-      bottomNavigationBar: const ProjectBottomNavbar(),
     ));
   }
 

--- a/lib/screens/events/event_view.dart
+++ b/lib/screens/events/event_view.dart
@@ -46,8 +46,7 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
     final services = CollEventServices(ref: ref);
     // Reconcile page/selection bookkeeping outside build (see site_view.dart).
     ref.listen(collEventEntryProvider, (_, next) {
-      // Skip refresh emissions: an in-progress refresh still carries the
-      // previous list (see site_view.dart).
+      // Skip refresh emissions (see site_view.dart).
       if (next.isLoading) return;
       next.whenData(_reconcile);
     });
@@ -157,9 +156,7 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
       }
     });
     if (landIndex != null) {
-      // The PageView is keyed by the controller, so this rebuilds it with a
-      // fresh scroll position that starts exactly on the target page — a
-      // jump on the live controller would race the refreshed list's layout.
+      // Keyed controller swap (see site_view.dart).
       _pageNav.openControllerAt(index);
     } else {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -168,9 +165,7 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
     }
   }
 
-  /// One-shot landing target for this refresh: a just-created record once it
-  /// appears in the list, or the last record on this State's first data load
-  /// (the old push-a-fresh-viewer-per-tab flow always landed at the end).
+  /// One-shot landing target for this refresh (see site_view.dart).
   int? _landingIndex(List<CollEventData> collEventEntries) {
     final firstLoad = !_loadedOnce;
     _loadedOnce = true;
@@ -220,8 +215,7 @@ class CollEventPages extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
-      // Keyed by controller identity so openControllerAt lands on its page
-      // via a fresh scroll position (see site_view.dart).
+      // Keyed by controller identity (see site_view.dart).
       key: ObjectKey(pageNav.pageController),
       controller: pageNav.pageController,
       itemCount: collEventEntries.length,

--- a/lib/screens/events/event_view.dart
+++ b/lib/screens/events/event_view.dart
@@ -141,7 +141,7 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
       _isVisible = count >= 2;
       if (count == 0) {
         _collEvenId = null;
-      } else if (_collEvenId != null &&
+      } else if (_collEvenId == null ||
           !collEventEntries.any((event) => event.id == _collEvenId)) {
         _collEvenId = collEventEntries[index].id;
       }

--- a/lib/screens/events/event_view.dart
+++ b/lib/screens/events/event_view.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/fields.dart';
 import 'package:nahpu/screens/shared/forms.dart';
-import 'package:nahpu/screens/shared/layout.dart';
 import 'package:nahpu/services/collevent_services.dart';
 import 'package:nahpu/services/database/database.dart';
 import 'package:nahpu/services/navigation_services.dart';
@@ -43,8 +42,7 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
   @override
   Widget build(BuildContext context) {
     final services = CollEventServices(ref: ref);
-    return FalseWillPop(
-        child: Scaffold(
+    return Scaffold(
       appBar: AppBar(
         title: const Text("Events"),
         actions: [
@@ -88,10 +86,6 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
                       _isSearching = false;
                       _searchController.clear();
                       services.invalidateCollEvent();
-                      Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(builder: (context) => super.widget),
-                      );
                     });
                   },
                   child: const Text("Cancel")),
@@ -148,7 +142,7 @@ class CollEventViewerState extends ConsumerState<CollEventViewer> {
           pageNav: _pageNav,
         ),
       ),
-    ));
+    );
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/home/components/body.dart
+++ b/lib/screens/home/components/body.dart
@@ -212,10 +212,7 @@ class ProjectViewState extends ConsumerState<ProjectView> {
       // Always open a project on the Dashboard tab.
       ref.read(projectNavbarIndexProvider.notifier).state = 0;
 
-      Navigator.push(
-        context,
-        MaterialPageRoute(builder: (context) => const ProjectShell()),
-      );
+      Navigator.push(context, ProjectShell.route());
     };
   }
 }

--- a/lib/screens/home/components/body.dart
+++ b/lib/screens/home/components/body.dart
@@ -3,7 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:nahpu/services/database/database.dart' as db;
 import 'package:nahpu/services/providers/projects.dart';
-import 'package:nahpu/screens/projects/dashboard.dart';
+import 'package:nahpu/screens/shared/project_shell.dart';
 import 'package:nahpu/screens/projects/components/project_info.dart';
 import 'package:nahpu/screens/shared/common.dart';
 import 'package:nahpu/services/database/project_queries.dart';
@@ -209,10 +209,12 @@ class ProjectViewState extends ConsumerState<ProjectView> {
   VoidCallback _openProject() {
     return () {
       ProjectServices(ref: ref).updateProjectUuid(widget.project.uuid);
+      // Always open a project on the Dashboard tab.
+      ref.read(projectNavbarIndexProvider.notifier).state = 0;
 
       Navigator.push(
         context,
-        MaterialPageRoute(builder: (context) => const Dashboard()),
+        MaterialPageRoute(builder: (context) => const ProjectShell()),
       );
     };
   }

--- a/lib/screens/narrative/components/menu_bar.dart
+++ b/lib/screens/narrative/components/menu_bar.dart
@@ -2,6 +2,7 @@ import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
 import 'package:nahpu/services/narrative_services.dart';
 import 'package:nahpu/services/providers/narrative.dart';
+import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/services/providers/projects.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
@@ -15,8 +16,11 @@ enum MenuSelection {
 }
 
 Future<void> createNewNarrative(BuildContext context, WidgetRef ref) {
-  return NarrativeServices(ref: ref).createNewNarrative().then((_) {
-    // NarrativeViewer stays mounted in ProjectShell; refresh it in place.
+  return NarrativeServices(ref: ref).createNewNarrative().then((newId) {
+    // NarrativeViewer stays mounted in ProjectShell; refresh it in place and
+    // land on the new narrative once it appears in the refreshed list.
+    ref.read(pendingRecordJumpProvider(RecordViewer.narrative).notifier).state =
+        newId;
     ref.invalidate(narrativeEntryProvider);
   });
 }

--- a/lib/screens/narrative/components/menu_bar.dart
+++ b/lib/screens/narrative/components/menu_bar.dart
@@ -17,8 +17,8 @@ enum MenuSelection {
 
 Future<void> createNewNarrative(BuildContext context, WidgetRef ref) {
   return NarrativeServices(ref: ref).createNewNarrative().then((newId) {
-    // NarrativeViewer stays mounted in ProjectShell; refresh it in place and
-    // land on the new narrative once it appears in the refreshed list.
+    // Refresh the always-mounted viewer in place and land on the new
+    // narrative.
     ref.read(pendingRecordJumpProvider(RecordViewer.narrative).notifier).state =
         newId;
     ref.invalidate(narrativeEntryProvider);
@@ -116,7 +116,7 @@ class NarrativeMenuState extends ConsumerState<NarrativeMenu> {
           try {
             await NarrativeServices(ref: ref)
                 .deleteNarrative(widget.narrativeId!);
-            // Close the delete dialog and refresh the list in place.
+            // Close the delete dialog.
             if (mounted) {
               Navigator.of(context).pop();
             }

--- a/lib/screens/narrative/components/menu_bar.dart
+++ b/lib/screens/narrative/components/menu_bar.dart
@@ -1,7 +1,7 @@
-import 'package:nahpu/screens/narrative/narrative_view.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
 import 'package:nahpu/services/narrative_services.dart';
+import 'package:nahpu/services/providers/narrative.dart';
 import 'package:nahpu/services/providers/projects.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
@@ -16,10 +16,8 @@ enum MenuSelection {
 
 Future<void> createNewNarrative(BuildContext context, WidgetRef ref) {
   return NarrativeServices(ref: ref).createNewNarrative().then((_) {
-    if (context.mounted) {
-      Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (_) => const NarrativeViewer()));
-    }
+    // NarrativeViewer stays mounted in ProjectShell; refresh it in place.
+    ref.invalidate(narrativeEntryProvider);
   });
 }
 
@@ -114,9 +112,11 @@ class NarrativeMenuState extends ConsumerState<NarrativeMenu> {
           try {
             await NarrativeServices(ref: ref)
                 .deleteNarrative(widget.narrativeId!);
-            if (context.mounted) {
-              _navigateToNarrative();
+            // Close the delete dialog and refresh the list in place.
+            if (mounted) {
+              Navigator.of(context).pop();
             }
+            ref.invalidate(narrativeEntryProvider);
           } catch (e) {
             if (context.mounted) {
               _showError(e.toString());
@@ -125,12 +125,6 @@ class NarrativeMenuState extends ConsumerState<NarrativeMenu> {
         }
       },
     );
-  }
-
-  void _navigateToNarrative() {
-    Navigator.of(context).pop();
-    Navigator.pushReplacement(
-        context, MaterialPageRoute(builder: (_) => const NarrativeViewer()));
   }
 
   void _showError(String errors) {

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -43,6 +43,10 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
   @override
   Widget build(BuildContext context) {
     final narrativeServices = NarrativeServices(ref: ref);
+    // Reconcile page/selection bookkeeping outside build (see site_view.dart).
+    ref.listen(narrativeEntryProvider, (_, next) {
+      next.whenData(_reconcile);
+    });
     return Scaffold(
       appBar: AppBar(
         title: const Text("Narrative"),
@@ -103,35 +107,19 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
           child: ref.watch(narrativeEntryProvider).when(
                 data: (narrativeEntries) {
                   if (narrativeEntries.isEmpty) {
-                    setState(() {
-                      isVisible = false;
-                      _narrativeId = null;
-                    });
-
                     return EmptyNarrative(isButtonVisible: !_isSearching);
-                  } else {
-                    int narrativeSize = narrativeEntries.length;
-                    setState(() {
-                      if (narrativeSize >= 2) {
-                        isVisible = true;
-                      } else {
-                        isVisible = false;
-                      }
-                      _pageNav.pageCounts = narrativeSize;
-                      _pageNav.updatePageController();
-                    });
-                    return NarrativePages(
-                      narrativeEntries: narrativeEntries,
-                      isNavButtonVisible: isVisible,
-                      pageNav: _pageNav,
-                      onPageChanged: (index) {
-                        setState(() {
-                          _narrativeId = narrativeEntries[index].id;
-                          _updatePageNav(index);
-                        });
-                      },
-                    );
                   }
+                  return NarrativePages(
+                    narrativeEntries: narrativeEntries,
+                    isNavButtonVisible: isVisible,
+                    pageNav: _pageNav,
+                    onPageChanged: (index) {
+                      setState(() {
+                        _narrativeId = narrativeEntries[index].id;
+                        _updatePageNav(index);
+                      });
+                    },
+                  );
                 },
                 loading: () => const CommonProgressIndicator(),
                 error: (error, stack) => Text(error.toString()),
@@ -145,6 +133,24 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
         ),
       ),
     );
+  }
+
+  void _reconcile(List<NarrativeData> narrativeEntries) {
+    if (!mounted) return;
+    final count = narrativeEntries.length;
+    final index = _pageNav.clampToCount(count);
+    setState(() {
+      isVisible = count >= 2;
+      if (count == 0) {
+        _narrativeId = null;
+      } else if (_narrativeId != null &&
+          !narrativeEntries.any((narrative) => narrative.id == _narrativeId)) {
+        _narrativeId = narrativeEntries[index].id;
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _pageNav.clampController(index);
+    });
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -47,6 +47,9 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
     final narrativeServices = NarrativeServices(ref: ref);
     // Reconcile page/selection bookkeeping outside build (see site_view.dart).
     ref.listen(narrativeEntryProvider, (_, next) {
+      // Skip refresh emissions: an in-progress refresh still carries the
+      // previous list (see site_view.dart).
+      if (next.isLoading) return;
       next.whenData(_reconcile);
     });
     return Scaffold(
@@ -155,13 +158,12 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
         _narrativeId = narrativeEntries[index].id;
       }
     });
-    if (landIndex != null && !_pageNav.pageController.hasClients) {
-      // First attach: a fresh controller opens the PageView directly on the
-      // target page (initialPage only applies to a newly created position).
+    if (landIndex != null) {
+      // The PageView is keyed by the controller, so this rebuilds it with a
+      // fresh scroll position that starts exactly on the target page — a
+      // jump on the live controller would race the refreshed list's layout.
       _pageNav.openControllerAt(index);
     } else {
-      // Attached PageView: a controller swap would re-attach the existing
-      // scroll position unchanged, so jump after the rebuilt frame instead.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _pageNav.clampController(index);
       });
@@ -218,6 +220,9 @@ class NarrativePages extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
+      // Keyed by controller identity so openControllerAt lands on its page
+      // via a fresh scroll position (see site_view.dart).
+      key: ObjectKey(pageNav.pageController),
       controller: pageNav.pageController,
       itemCount: narrativeEntries.length,
       itemBuilder: (context, index) {

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/fields.dart';
 import 'package:nahpu/screens/shared/forms.dart';
-import 'package:nahpu/screens/shared/layout.dart';
 import 'package:nahpu/services/narrative_services.dart';
 import 'package:nahpu/services/navigation_services.dart';
 import 'package:nahpu/services/types/controllers.dart';
@@ -44,8 +43,7 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
   @override
   Widget build(BuildContext context) {
     final narrativeServices = NarrativeServices(ref: ref);
-    return FalseWillPop(
-        child: Scaffold(
+    return Scaffold(
       appBar: AppBar(
         title: const Text("Narrative"),
         actions: [
@@ -90,10 +88,6 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
                       _isSearching = false;
                       _searchController.clear();
                       narrativeServices.invalidateNarrative();
-                      Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => super.widget));
                     });
                   },
                   child: const Text('Cancel')),
@@ -150,7 +144,7 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
           pageNav: _pageNav,
         ),
       ),
-    ));
+    );
   }
 
   void _updatePageNav(int value) {
@@ -202,7 +196,8 @@ class NarrativePages extends StatelessWidget {
     // to parse a time from the existing date string for backwards
     // compatibility with old data.
     String? timeStd = narrativeEntries[index].time;
-    if ((timeStd == null || timeStd.isEmpty) && narrativeEntries[index].date != null) {
+    if ((timeStd == null || timeStd.isEmpty) &&
+        narrativeEntries[index].date != null) {
       final storedDate = narrativeEntries[index].date!;
       final parsed = DateTime.tryParse(storedDate);
       if (parsed != null) {

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -155,9 +155,13 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
         _narrativeId = narrativeEntries[index].id;
       }
     });
-    if (landIndex != null) {
+    if (landIndex != null && !_pageNav.pageController.hasClients) {
+      // First attach: a fresh controller opens the PageView directly on the
+      // target page (initialPage only applies to a newly created position).
       _pageNav.openControllerAt(index);
     } else {
+      // Attached PageView: a controller swap would re-attach the existing
+      // scroll position unchanged, so jump after the rebuilt frame instead.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _pageNav.clampController(index);
       });

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -150,7 +150,6 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
           pageNav: _pageNav,
         ),
       ),
-      bottomNavigationBar: const ProjectBottomNavbar(),
     ));
   }
 

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -6,6 +6,7 @@ import 'package:nahpu/services/narrative_services.dart';
 import 'package:nahpu/services/navigation_services.dart';
 import 'package:nahpu/services/types/controllers.dart';
 import 'package:nahpu/services/providers/narrative.dart';
+import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/screens/narrative/components/menu_bar.dart';
 import 'package:nahpu/screens/narrative/narrative_form.dart';
 import 'package:nahpu/screens/shared/common.dart';
@@ -24,6 +25,7 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
   final PageNavigation _pageNav = PageNavigation.init();
   final TextEditingController _searchController = TextEditingController();
   int? _narrativeId;
+  bool _loadedOnce = false;
   bool _isSearching = false;
   late FocusNode _focus;
 
@@ -138,19 +140,52 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
   void _reconcile(List<NarrativeData> narrativeEntries) {
     if (!mounted) return;
     final count = narrativeEntries.length;
+    final landIndex = _landingIndex(narrativeEntries);
+    if (landIndex != null) {
+      _pageNav.currentPage = landIndex + 1;
+    }
     final index = _pageNav.clampToCount(count);
     setState(() {
       isVisible = count >= 2;
       if (count == 0) {
         _narrativeId = null;
-      } else if (_narrativeId == null ||
+      } else if (landIndex != null ||
+          _narrativeId == null ||
           !narrativeEntries.any((narrative) => narrative.id == _narrativeId)) {
         _narrativeId = narrativeEntries[index].id;
       }
     });
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _pageNav.clampController(index);
-    });
+    if (landIndex != null) {
+      _pageNav.openControllerAt(index);
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _pageNav.clampController(index);
+      });
+    }
+  }
+
+  /// One-shot landing target for this refresh: a just-created record once it
+  /// appears in the list, or the last record on this State's first data load
+  /// (the old push-a-fresh-viewer-per-tab flow always landed at the end).
+  int? _landingIndex(List<NarrativeData> narrativeEntries) {
+    final firstLoad = !_loadedOnce;
+    _loadedOnce = true;
+    final pendingJump =
+        ref.read(pendingRecordJumpProvider(RecordViewer.narrative));
+    if (pendingJump != null) {
+      final target =
+          narrativeEntries.indexWhere((narrative) => narrative.id == pendingJump);
+      if (target != -1) {
+        ref
+            .read(pendingRecordJumpProvider(RecordViewer.narrative).notifier)
+            .state = null;
+        return target;
+      }
+    }
+    if (firstLoad && narrativeEntries.isNotEmpty) {
+      return narrativeEntries.length - 1;
+    }
+    return null;
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -47,8 +47,7 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
     final narrativeServices = NarrativeServices(ref: ref);
     // Reconcile page/selection bookkeeping outside build (see site_view.dart).
     ref.listen(narrativeEntryProvider, (_, next) {
-      // Skip refresh emissions: an in-progress refresh still carries the
-      // previous list (see site_view.dart).
+      // Skip refresh emissions (see site_view.dart).
       if (next.isLoading) return;
       next.whenData(_reconcile);
     });
@@ -159,9 +158,7 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
       }
     });
     if (landIndex != null) {
-      // The PageView is keyed by the controller, so this rebuilds it with a
-      // fresh scroll position that starts exactly on the target page — a
-      // jump on the live controller would race the refreshed list's layout.
+      // Keyed controller swap (see site_view.dart).
       _pageNav.openControllerAt(index);
     } else {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -170,9 +167,7 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
     }
   }
 
-  /// One-shot landing target for this refresh: a just-created record once it
-  /// appears in the list, or the last record on this State's first data load
-  /// (the old push-a-fresh-viewer-per-tab flow always landed at the end).
+  /// One-shot landing target for this refresh (see site_view.dart).
   int? _landingIndex(List<NarrativeData> narrativeEntries) {
     final firstLoad = !_loadedOnce;
     _loadedOnce = true;
@@ -220,8 +215,7 @@ class NarrativePages extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
-      // Keyed by controller identity so openControllerAt lands on its page
-      // via a fresh scroll position (see site_view.dart).
+      // Keyed by controller identity (see site_view.dart).
       key: ObjectKey(pageNav.pageController),
       controller: pageNav.pageController,
       itemCount: narrativeEntries.length,

--- a/lib/screens/narrative/narrative_view.dart
+++ b/lib/screens/narrative/narrative_view.dart
@@ -143,7 +143,7 @@ class NarrativeViewerState extends ConsumerState<NarrativeViewer> {
       isVisible = count >= 2;
       if (count == 0) {
         _narrativeId = null;
-      } else if (_narrativeId != null &&
+      } else if (_narrativeId == null ||
           !narrativeEntries.any((narrative) => narrative.id == _narrativeId)) {
         _narrativeId = narrativeEntries[index].id;
       }

--- a/lib/screens/projects/components/action_buttons.dart
+++ b/lib/screens/projects/components/action_buttons.dart
@@ -12,10 +12,8 @@ import 'package:nahpu/services/types/specimens.dart';
 class ActionButtons extends ConsumerWidget {
   const ActionButtons({super.key});
 
-  /// The Dashboard is not the tab that displays the created record, so after
-  /// a successful create switch the shell to the owning tab ([index] into
-  /// [defaultProjectPages]); the pending record jump then lands the viewer on
-  /// the new record.
+  /// Switches the shell to the tab that displays the created record ([index]
+  /// into [defaultProjectPages]); the pending jump then lands the viewer on it.
   void _showTab(WidgetRef ref, int index) {
     ref.read(projectNavbarIndexProvider.notifier).state = index;
   }

--- a/lib/screens/projects/components/action_buttons.dart
+++ b/lib/screens/projects/components/action_buttons.dart
@@ -6,10 +6,19 @@ import 'package:nahpu/screens/sites/components/menu_bar.dart';
 import 'package:nahpu/screens/narrative/components/menu_bar.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/specimens/shared/menu_bar.dart';
+import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/types/specimens.dart';
 
 class ActionButtons extends ConsumerWidget {
   const ActionButtons({super.key});
+
+  /// The Dashboard is not the tab that displays the created record, so after
+  /// a successful create switch the shell to the owning tab ([index] into
+  /// [defaultProjectPages]); the pending record jump then lands the viewer on
+  /// the new record.
+  void _showTab(WidgetRef ref, int index) {
+    ref.read(projectNavbarIndexProvider.notifier).state = index;
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -28,6 +37,7 @@ class ActionButtons extends ConsumerWidget {
           label: 'Create site',
           onTap: () async {
             await createNewSite(context, ref);
+            _showTab(ref, 1);
           },
         ),
         SpeedDialChild(
@@ -37,6 +47,7 @@ class ActionButtons extends ConsumerWidget {
           label: 'Create event',
           onTap: () async {
             await createNewCollEvents(context, ref);
+            _showTab(ref, 2);
           },
         ),
         SpeedDialChild(
@@ -53,6 +64,7 @@ class ActionButtons extends ConsumerWidget {
           label: 'Create specimen',
           onTap: () async {
             await createNewSpecimens(context, ref);
+            _showTab(ref, 3);
           },
         ),
         SpeedDialChild(
@@ -62,6 +74,7 @@ class ActionButtons extends ConsumerWidget {
             label: 'Create narrative',
             onTap: () async {
               await createNewNarrative(context, ref);
+              _showTab(ref, 4);
             }),
       ],
     );

--- a/lib/screens/projects/components/project_form.dart
+++ b/lib/screens/projects/components/project_form.dart
@@ -11,8 +11,9 @@ import 'package:nahpu/services/types/specimens.dart';
 import 'package:nahpu/services/utility_services.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/fields.dart';
-import 'package:nahpu/screens/projects/dashboard.dart';
+import 'package:nahpu/screens/shared/project_shell.dart';
 import 'package:nahpu/services/database/database.dart';
+import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/providers/validation.dart';
 
 class ProjectForm extends ConsumerStatefulWidget {
@@ -288,10 +289,14 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
   }
 
   Future<void> _goToDashboard() async {
-    await Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(builder: (context) => const Dashboard()),
-    );
+    ref.read(projectNavbarIndexProvider.notifier).state = 0;
+    if (widget.isEditing) {
+      // The shell is still below the edit form; return to it in place.
+      ProjectShell.popToShell(context);
+    } else {
+      // A new project has no shell yet; open one for it.
+      await Navigator.pushReplacement(context, ProjectShell.route());
+    }
   }
 }
 

--- a/lib/screens/projects/components/project_form.dart
+++ b/lib/screens/projects/components/project_form.dart
@@ -294,10 +294,8 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
       // The shell is still below the edit form; return to it in place.
       ProjectShell.popToShell(context);
     } else {
-      // Creating a project switches projectUuidProvider to the new project
-      // (see ProjectServices.createProject). Clear any screens back to Home,
-      // then open a single shell for it. This works whether the form was
-      // launched from Home or from inside another open project, so a second
+      // createProject already pointed projectUuidProvider at the new project.
+      // Pop everything back to Home and open one shell for it, so a second
       // shell can never stack on top of an existing one.
       Navigator.of(context).popUntil((route) => route.isFirst);
       Navigator.of(context).push(ProjectShell.route());

--- a/lib/screens/projects/components/project_form.dart
+++ b/lib/screens/projects/components/project_form.dart
@@ -288,14 +288,19 @@ class ProjectFormState extends ConsumerState<ProjectForm> {
     ProjectServices(ref: ref).updateProject(widget.projectUuid, projectData);
   }
 
-  Future<void> _goToDashboard() async {
+  void _goToDashboard() {
     ref.read(projectNavbarIndexProvider.notifier).state = 0;
     if (widget.isEditing) {
       // The shell is still below the edit form; return to it in place.
       ProjectShell.popToShell(context);
     } else {
-      // A new project has no shell yet; open one for it.
-      await Navigator.pushReplacement(context, ProjectShell.route());
+      // Creating a project switches projectUuidProvider to the new project
+      // (see ProjectServices.createProject). Clear any screens back to Home,
+      // then open a single shell for it. This works whether the form was
+      // launched from Home or from inside another open project, so a second
+      // shell can never stack on top of an existing one.
+      Navigator.of(context).popUntil((route) => route.isFirst);
+      Navigator.of(context).push(ProjectShell.route());
     }
   }
 }

--- a/lib/screens/projects/dashboard.dart
+++ b/lib/screens/projects/dashboard.dart
@@ -31,29 +31,27 @@ class DashboardState extends ConsumerState<Dashboard> {
 
   @override
   Widget build(BuildContext context) {
-    return FalseWillPop(
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text("Project Dashboard"),
-        ),
-        floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
-        floatingActionButton: const ActionButtons(),
-        drawer: const ProjectMenuDrawer(),
-        body: LayoutBuilder(
-          builder: (BuildContext context, BoxConstraints c) {
-            bool useHorizontalLayout = c.maxWidth > 600;
-            return SafeArea(
-              child: SingleChildScrollView(
-                child: Column(
-                  children: [
-                    TopPanel(useHorizontalLayout: useHorizontalLayout),
-                    BottomPanel(useHorizontalLayout: useHorizontalLayout)
-                  ],
-                ),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("Project Dashboard"),
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endTop,
+      floatingActionButton: const ActionButtons(),
+      drawer: const ProjectMenuDrawer(),
+      body: LayoutBuilder(
+        builder: (BuildContext context, BoxConstraints c) {
+          bool useHorizontalLayout = c.maxWidth > 600;
+          return SafeArea(
+            child: SingleChildScrollView(
+              child: Column(
+                children: [
+                  TopPanel(useHorizontalLayout: useHorizontalLayout),
+                  BottomPanel(useHorizontalLayout: useHorizontalLayout)
+                ],
               ),
-            );
-          },
-        ),
+            ),
+          );
+        },
       ),
     );
   }

--- a/lib/screens/projects/dashboard.dart
+++ b/lib/screens/projects/dashboard.dart
@@ -8,7 +8,6 @@ import 'package:nahpu/screens/projects/components/overview.dart';
 import 'package:nahpu/screens/projects/personnel/personnel.dart';
 import 'package:nahpu/screens/projects/taxonomy/taxon_registry.dart';
 import 'package:nahpu/screens/projects/edit_project.dart';
-import 'package:nahpu/screens/shared/navigation.dart';
 import 'package:nahpu/screens/shared/layout.dart';
 import 'package:nahpu/styles/catalog_pages.dart';
 
@@ -55,7 +54,6 @@ class DashboardState extends ConsumerState<Dashboard> {
             );
           },
         ),
-        bottomNavigationBar: const ProjectBottomNavbar(),
       ),
     );
   }

--- a/lib/screens/projects/personnel/select_personnel.dart
+++ b/lib/screens/projects/personnel/select_personnel.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/services/providers/personnel.dart';
-import 'package:nahpu/screens/projects/dashboard.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
+import 'package:nahpu/screens/shared/project_shell.dart';
 import 'package:nahpu/screens/shared/common.dart';
 import 'package:nahpu/screens/shared/fields.dart';
 import 'package:nahpu/screens/shared/layout.dart';
@@ -197,11 +197,7 @@ class AddPersonnelSelectionState extends ConsumerState<AddPersonnelSelection> {
                         await _addSelectedPersonnelToProject();
                         ref.invalidate(projectPersonnelProvider);
                         if (context.mounted) {
-                          Navigator.of(context).pushReplacement(
-                            MaterialPageRoute(
-                              builder: (context) => const Dashboard(),
-                            ),
-                          );
+                          ProjectShell.returnToTab(context, ref, 0);
                         }
                       } catch (e) {
                         if (context.mounted) {

--- a/lib/screens/projects/statistics/statistics.dart
+++ b/lib/screens/projects/statistics/statistics.dart
@@ -69,7 +69,9 @@ class StatisticViewerState extends ConsumerState<StatisticViewer> {
             const SizedBox(height: 16),
             PrimaryButton(
               onPressed: () {
-                Navigator.pushReplacement(
+                // Push the fullscreen view on top of the shell so its Close
+                // button can pop back to the shell.
+                Navigator.push(
                   context,
                   _openFullscreen(),
                 );

--- a/lib/screens/projects/statistics/statistics.dart
+++ b/lib/screens/projects/statistics/statistics.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/material.dart';
-import 'package:nahpu/screens/projects/dashboard.dart';
 import 'package:nahpu/screens/projects/statistics/charts.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
+import 'package:nahpu/screens/shared/project_shell.dart';
 import 'package:nahpu/screens/shared/forms.dart';
 import 'package:nahpu/services/collevent_services.dart';
 import 'package:nahpu/services/database/database.dart';
@@ -154,10 +154,7 @@ class StatisticFullScreenState extends ConsumerState<StatisticFullScreen> {
           tooltip: 'Close',
           icon: const Icon(Icons.close_rounded),
           onPressed: () {
-            Navigator.pushReplacement(
-              context,
-              _closeFullscreen(),
-            );
+            ProjectShell.returnToTab(context, ref, 0);
           },
         ),
       ),
@@ -316,20 +313,6 @@ class StatisticFullScreenState extends ConsumerState<StatisticFullScreen> {
       default:
         return {};
     }
-  }
-
-  Route _closeFullscreen() {
-    return PageRouteBuilder(
-      pageBuilder: (context, animation, secondaryAnimation) =>
-          const Dashboard(),
-      transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        const begin = Offset(0.0, 0.0);
-        const end = Offset.zero;
-        final tween = Tween(begin: begin, end: end);
-        final offsetAnimation = animation.drive(tween);
-        return SlideTransition(position: offsetAnimation, child: child);
-      },
-    );
   }
 }
 

--- a/lib/screens/projects/statistics/statistics.dart
+++ b/lib/screens/projects/statistics/statistics.dart
@@ -69,8 +69,7 @@ class StatisticViewerState extends ConsumerState<StatisticViewer> {
             const SizedBox(height: 16),
             PrimaryButton(
               onPressed: () {
-                // Push the fullscreen view on top of the shell so its Close
-                // button can pop back to the shell.
+                // Pushed on top of the shell; Close pops back to it.
                 Navigator.push(
                   context,
                   _openFullscreen(),

--- a/lib/screens/projects/taxonomy/import_taxa.dart
+++ b/lib/screens/projects/taxonomy/import_taxa.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:nahpu/screens/projects/dashboard.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/fields.dart';
 import 'package:nahpu/screens/shared/layout.dart';
@@ -13,6 +12,7 @@ import 'package:nahpu/screens/shared/file_operation.dart';
 import 'package:nahpu/services/types/import.dart';
 import 'package:nahpu/services/import/taxon_entry.dart';
 import 'package:nahpu/services/utility_services.dart';
+import 'package:nahpu/screens/shared/project_shell.dart';
 import 'package:path/path.dart' as p;
 import 'package:share_plus/share_plus.dart';
 
@@ -691,11 +691,7 @@ class ImportRecords extends StatelessWidget {
             child: IconButton(
                 icon: const Icon(Icons.close),
                 onPressed: () {
-                  Navigator.of(context).pushReplacement(
-                    MaterialPageRoute(
-                      builder: (context) => const Dashboard(),
-                    ),
-                  );
+                  ProjectShell.popToShell(context);
                 })),
       ),
       body: SafeArea(

--- a/lib/screens/shared/buttons.dart
+++ b/lib/screens/shared/buttons.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:nahpu/services/providers/projects.dart';
-import 'package:nahpu/screens/projects/dashboard.dart';
+import 'package:nahpu/screens/shared/project_shell.dart';
 
 class ProjectBackButton extends ConsumerWidget {
   const ProjectBackButton({super.key});
@@ -9,12 +8,7 @@ class ProjectBackButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return BackButton(
-      onPressed: () {
-        Navigator.push(context, MaterialPageRoute(builder: (context) {
-          return const Dashboard();
-        }));
-        ref.read(projectNavbarIndexProvider.notifier).state = 0;
-      },
+      onPressed: () => ProjectShell.returnToTab(context, ref, 0),
     );
   }
 }

--- a/lib/screens/shared/navigation.dart
+++ b/lib/screens/shared/navigation.dart
@@ -73,10 +73,9 @@ class ProjectBottomNavbarState extends ConsumerState<ProjectBottomNavbar> {
     );
   }
 
-  /// Refreshes the data shown by the destination tab (and any data it depends
-  /// on). Because [ProjectShell] keeps every screen alive in an [IndexedStack],
-  /// their auto-dispose providers never lose their listeners, so this explicit
-  /// invalidation is the only thing that re-fetches data on a tab switch.
+  /// Re-fetches the destination tab's data. [ProjectShell]'s [IndexedStack]
+  /// keeps every screen's providers alive, so this explicit invalidation is
+  /// the only re-fetch on a tab switch.
   void _onItemTapped(int index) {
     switch (index) {
       case 0:

--- a/lib/screens/shared/navigation.dart
+++ b/lib/screens/shared/navigation.dart
@@ -7,12 +7,7 @@ import 'package:nahpu/services/navigation_services.dart';
 import 'package:nahpu/services/platform_services.dart';
 import 'package:nahpu/services/types/specimens.dart';
 import 'package:nahpu/services/providers/projects.dart';
-import 'package:nahpu/screens/narrative/narrative_view.dart';
-import 'package:nahpu/screens/events/event_view.dart';
 import 'package:nahpu/services/providers/specimens.dart';
-import 'package:nahpu/screens/sites/site_view.dart';
-import 'package:nahpu/screens/specimens/specimen_view.dart';
-import 'package:nahpu/screens/projects/dashboard.dart';
 
 class ProjectBottomNavbar extends ConsumerStatefulWidget {
   const ProjectBottomNavbar({super.key});
@@ -34,7 +29,6 @@ class ProjectBottomNavbarState extends ConsumerState<ProjectBottomNavbar> {
           Theme.of(context).colorScheme.secondary, 0.1),
       indicatorColor: Theme.of(context).colorScheme.secondaryContainer,
       elevation: 10,
-      animationDuration: const Duration(seconds: 3),
       selectedIndex: selectedIndex,
       destinations: const [
         NavigationDestination(
@@ -79,48 +73,29 @@ class ProjectBottomNavbarState extends ConsumerState<ProjectBottomNavbar> {
     );
   }
 
+  /// Refreshes the data shown by the destination tab (and any data it depends
+  /// on). Because [ProjectShell] keeps every screen alive in an [IndexedStack],
+  /// their auto-dispose providers never lose their listeners, so this explicit
+  /// invalidation is the only thing that re-fetches data on a tab switch.
   void _onItemTapped(int index) {
     switch (index) {
       case 0:
         _invalidateAll();
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(
-            builder: (context) => const Dashboard(),
-          ),
-        );
-
         break;
       case 1:
         ref.invalidate(siteEntryProvider);
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(builder: (context) => const SiteViewer()),
-        );
         break;
       case 2:
         ref.invalidate(siteEntryProvider);
         ref.invalidate(collEventEntryProvider);
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(builder: (context) => const CollEventViewer()),
-        );
         break;
       case 3:
         ref.invalidate(collEventEntryProvider);
         ref.invalidate(specimenEntryProvider);
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(builder: (context) => const SpecimenViewer()),
-        );
         break;
       case 4:
         ref.invalidate(siteEntryProvider);
         ref.invalidate(narrativeEntryProvider);
-        Navigator.pushReplacement(
-          context,
-          MaterialPageRoute(builder: (context) => const NarrativeViewer()),
-        );
         break;
     }
   }

--- a/lib/screens/shared/project_shell.dart
+++ b/lib/screens/shared/project_shell.dart
@@ -9,9 +9,7 @@ import 'package:nahpu/screens/sites/site_view.dart';
 import 'package:nahpu/screens/specimens/specimen_view.dart';
 import 'package:nahpu/services/providers/projects.dart';
 
-/// The top-level project pages, in the same order as the destinations in
-/// [ProjectBottomNavbar]. The index into this list is driven by
-/// [projectNavbarIndexProvider].
+/// The top-level project pages, in [ProjectBottomNavbar] destination order.
 const List<Widget> defaultProjectPages = [
   Dashboard(),
   SiteViewer(),
@@ -20,26 +18,19 @@ const List<Widget> defaultProjectPages = [
   NarrativeViewer(),
 ];
 
-/// Hosts the five top-level project screens in a single [Scaffold] and swaps
-/// between them in place via an [IndexedStack].
-///
-/// Selecting a tab in [ProjectBottomNavbar] only updates
-/// [projectNavbarIndexProvider]; it no longer pushes a new route, so there is
-/// no page-transition animation and each screen keeps its state across
-/// switches. [pages] is injectable so widget tests can supply lightweight
-/// stand-ins for the real screens.
+/// Hosts the five top-level project screens and swaps between them in place
+/// via an [IndexedStack] driven by [projectNavbarIndexProvider] — no route
+/// push, so screens keep their state across tab switches. [pages] is
+/// injectable so widget tests can supply lightweight stand-ins.
 class ProjectShell extends ConsumerWidget {
   const ProjectShell({super.key, this.pages = defaultProjectPages});
 
   final List<Widget> pages;
 
-  /// Route name used so screens pushed on top of the shell (forms, imports,
-  /// fullscreen views) can return to it with [popToShell] regardless of how
-  /// many routes are stacked above it.
+  /// Lets [popToShell] find the shell under any number of stacked routes.
   static const String routeName = 'project_shell';
 
-  /// The route used to open a project. Always carries [routeName] so
-  /// [popToShell] can find it.
+  /// The route used to open a project; carries [routeName] for [popToShell].
   static Route<void> route() {
     return MaterialPageRoute<void>(
       settings: const RouteSettings(name: routeName),

--- a/lib/screens/shared/project_shell.dart
+++ b/lib/screens/shared/project_shell.dart
@@ -33,6 +33,31 @@ class ProjectShell extends ConsumerWidget {
 
   final List<Widget> pages;
 
+  /// Route name used so screens pushed on top of the shell (forms, imports,
+  /// fullscreen views) can return to it with [popToShell] regardless of how
+  /// many routes are stacked above it.
+  static const String routeName = 'project_shell';
+
+  /// The route used to open a project. Always carries [routeName] so
+  /// [popToShell] can find it.
+  static Route<void> route() {
+    return MaterialPageRoute<void>(
+      settings: const RouteSettings(name: routeName),
+      builder: (_) => const ProjectShell(),
+    );
+  }
+
+  /// Pops every route stacked above the shell, returning to it in place.
+  static void popToShell(BuildContext context) {
+    Navigator.of(context).popUntil((route) => route.settings.name == routeName);
+  }
+
+  /// Selects [index] on the shell's navbar and returns to the shell.
+  static void returnToTab(BuildContext context, WidgetRef ref, int index) {
+    ref.read(projectNavbarIndexProvider.notifier).state = index;
+    popToShell(context);
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final index = ref.watch(projectNavbarIndexProvider);

--- a/lib/screens/shared/project_shell.dart
+++ b/lib/screens/shared/project_shell.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:nahpu/screens/events/event_view.dart';
+import 'package:nahpu/screens/narrative/narrative_view.dart';
+import 'package:nahpu/screens/projects/dashboard.dart';
+import 'package:nahpu/screens/shared/layout.dart';
+import 'package:nahpu/screens/shared/navigation.dart';
+import 'package:nahpu/screens/sites/site_view.dart';
+import 'package:nahpu/screens/specimens/specimen_view.dart';
+import 'package:nahpu/services/providers/projects.dart';
+
+/// The top-level project pages, in the same order as the destinations in
+/// [ProjectBottomNavbar]. The index into this list is driven by
+/// [projectNavbarIndexProvider].
+const List<Widget> defaultProjectPages = [
+  Dashboard(),
+  SiteViewer(),
+  CollEventViewer(),
+  SpecimenViewer(),
+  NarrativeViewer(),
+];
+
+/// Hosts the five top-level project screens in a single [Scaffold] and swaps
+/// between them in place via an [IndexedStack].
+///
+/// Selecting a tab in [ProjectBottomNavbar] only updates
+/// [projectNavbarIndexProvider]; it no longer pushes a new route, so there is
+/// no page-transition animation and each screen keeps its state across
+/// switches. [pages] is injectable so widget tests can supply lightweight
+/// stand-ins for the real screens.
+class ProjectShell extends ConsumerWidget {
+  const ProjectShell({super.key, this.pages = defaultProjectPages});
+
+  final List<Widget> pages;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final index = ref.watch(projectNavbarIndexProvider);
+    return FalseWillPop(
+      child: Scaffold(
+        body: IndexedStack(
+          index: index,
+          children: pages,
+        ),
+        bottomNavigationBar: const ProjectBottomNavbar(),
+      ),
+    );
+  }
+}

--- a/lib/screens/sites/components/menu_bar.dart
+++ b/lib/screens/sites/components/menu_bar.dart
@@ -2,13 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
+import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/providers/sites.dart';
 import 'package:nahpu/services/site_services.dart';
 
 Future<void> createNewSite(BuildContext context, WidgetRef ref) {
-  return SiteServices(ref: ref).createNewSite().then((_) {
-    // SiteViewer stays mounted in ProjectShell, so refresh its list in place.
+  return SiteServices(ref: ref).createNewSite().then((newId) {
+    // SiteViewer stays mounted in ProjectShell, so refresh its list in place
+    // and land on the new site once it appears in the refreshed list.
+    ref.read(pendingRecordJumpProvider(RecordViewer.site).notifier).state =
+        newId;
     ref.invalidate(siteEntryProvider);
   });
 }
@@ -122,7 +126,11 @@ class SiteMenuState extends ConsumerState<SiteMenu> {
 
   Future<void> _duplicateSite() async {
     try {
-      await SiteServices(ref: ref).duplicateSite(widget.siteId!);
+      final newId = await SiteServices(ref: ref).duplicateSite(widget.siteId!);
+      if (newId != null) {
+        ref.read(pendingRecordJumpProvider(RecordViewer.site).notifier).state =
+            newId;
+      }
       ref.invalidate(siteEntryProvider);
     } catch (e) {
       _showError(e.toString());

--- a/lib/screens/sites/components/menu_bar.dart
+++ b/lib/screens/sites/components/menu_bar.dart
@@ -9,8 +9,7 @@ import 'package:nahpu/services/site_services.dart';
 
 Future<void> createNewSite(BuildContext context, WidgetRef ref) {
   return SiteServices(ref: ref).createNewSite().then((newId) {
-    // SiteViewer stays mounted in ProjectShell, so refresh its list in place
-    // and land on the new site once it appears in the refreshed list.
+    // Refresh the always-mounted viewer in place and land on the new site.
     ref.read(pendingRecordJumpProvider(RecordViewer.site).notifier).state =
         newId;
     ref.invalidate(siteEntryProvider);
@@ -147,7 +146,7 @@ class SiteMenuState extends ConsumerState<SiteMenu> {
             try {
               await SiteServices(ref: ref).deleteSite(widget.siteId!);
 
-              // Close the delete dialog and refresh the list in place.
+              // Close the delete dialog.
               if (mounted) {
                 Navigator.pop(context);
               }

--- a/lib/screens/sites/components/menu_bar.dart
+++ b/lib/screens/sites/components/menu_bar.dart
@@ -2,16 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
-import 'package:nahpu/screens/sites/site_view.dart';
 import 'package:nahpu/services/providers/projects.dart';
+import 'package:nahpu/services/providers/sites.dart';
 import 'package:nahpu/services/site_services.dart';
 
 Future<void> createNewSite(BuildContext context, WidgetRef ref) {
   return SiteServices(ref: ref).createNewSite().then((_) {
-    if (context.mounted) {
-      Navigator.of(context).pushReplacement(
-          MaterialPageRoute(builder: (_) => const SiteViewer()));
-    }
+    // SiteViewer stays mounted in ProjectShell, so refresh its list in place.
+    ref.invalidate(siteEntryProvider);
   });
 }
 
@@ -125,17 +123,10 @@ class SiteMenuState extends ConsumerState<SiteMenu> {
   Future<void> _duplicateSite() async {
     try {
       await SiteServices(ref: ref).duplicateSite(widget.siteId!);
-      if (context.mounted) {
-        _navigateToSiteViewer();
-      }
+      ref.invalidate(siteEntryProvider);
     } catch (e) {
       _showError(e.toString());
     }
-  }
-
-  void _navigateToSiteViewer() {
-    Navigator.of(context)
-        .pushReplacement(MaterialPageRoute(builder: (_) => const SiteViewer()));
   }
 
   Future<void> _deleteSite() async {
@@ -148,21 +139,16 @@ class SiteMenuState extends ConsumerState<SiteMenu> {
             try {
               await SiteServices(ref: ref).deleteSite(widget.siteId!);
 
-              // Trigger page changes to update the view.
-              if (context.mounted) {
-                _navigateToSiteForm();
+              // Close the delete dialog and refresh the list in place.
+              if (mounted) {
+                Navigator.pop(context);
               }
+              ref.invalidate(siteEntryProvider);
             } catch (e) {
               _showError(e.toString());
             }
           }
         });
-  }
-
-  void _navigateToSiteForm() {
-    Navigator.pop(context);
-    Navigator.of(context)
-        .pushReplacement(MaterialPageRoute(builder: (_) => const SiteViewer()));
   }
 
   void _deleteAllSites() {

--- a/lib/screens/sites/site_view.dart
+++ b/lib/screens/sites/site_view.dart
@@ -46,13 +46,11 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
   @override
   Widget build(BuildContext context) {
     final siteEntries = ref.watch(siteEntryProvider);
-    // Reconcile page/selection bookkeeping outside build, so setState is legal
-    // and the always-mounted viewer survives an invalidate without resetting
-    // its scroll position or pointing the menu at a deleted record.
+    // Reconcile page/selection bookkeeping outside build, so setState is
+    // legal and the always-mounted viewer survives an invalidate.
     ref.listen(siteEntryProvider, (_, next) {
-      // Skip refresh emissions: an in-progress refresh still carries the
-      // previous list, and reconciling against it would consume landing
-      // requests with stale data.
+      // An in-progress refresh still carries the previous list; reconciling
+      // against it would consume landing requests with stale data.
       if (next.isLoading) return;
       next.whenData(_reconcile);
     });
@@ -163,9 +161,8 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
       }
     });
     if (landIndex != null) {
-      // The PageView is keyed by the controller, so this rebuilds it with a
-      // fresh scroll position that starts exactly on the target page — a
-      // jump on the live controller would race the refreshed list's layout.
+      // Keyed controller swap; a jump on the live controller would race the
+      // refreshed list's layout (see openControllerAt).
       _pageNav.openControllerAt(index);
     } else {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -174,9 +171,8 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
     }
   }
 
-  /// One-shot landing target for this refresh: a just-created record once it
-  /// appears in the list, or the last record on this State's first data load
-  /// (the old push-a-fresh-viewer-per-tab flow always landed at the end).
+  /// One-shot landing target for this refresh: a just-created record, or the
+  /// last record on first load (matching the old land-at-the-end behavior).
   int? _landingIndex(List<SiteData> siteEntries) {
     final firstLoad = !_loadedOnce;
     _loadedOnce = true;
@@ -221,9 +217,7 @@ class SitePages extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
-      // Keyed by controller identity: openControllerAt swaps the controller
-      // to land on a page, and the new element's fresh scroll position is
-      // what makes initialPage take effect.
+      // Keyed by controller identity so openControllerAt's swap takes effect.
       key: ObjectKey(pageNav.pageController),
       controller: pageNav.pageController,
       itemCount: siteEntries.length,

--- a/lib/screens/sites/site_view.dart
+++ b/lib/screens/sites/site_view.dart
@@ -148,7 +148,6 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
           child: PageNavButton(
             pageNav: _pageNav,
           )),
-      bottomNavigationBar: const ProjectBottomNavbar(),
     ));
   }
 

--- a/lib/screens/sites/site_view.dart
+++ b/lib/screens/sites/site_view.dart
@@ -158,9 +158,13 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
         _siteId = siteEntries[index].id;
       }
     });
-    if (landIndex != null) {
+    if (landIndex != null && !_pageNav.pageController.hasClients) {
+      // First attach: a fresh controller opens the PageView directly on the
+      // target page (initialPage only applies to a newly created position).
       _pageNav.openControllerAt(index);
     } else {
+      // Attached PageView: a controller swap would re-attach the existing
+      // scroll position unchanged, so jump after the rebuilt frame instead.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _pageNav.clampController(index);
       });

--- a/lib/screens/sites/site_view.dart
+++ b/lib/screens/sites/site_view.dart
@@ -44,6 +44,12 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
   @override
   Widget build(BuildContext context) {
     final siteEntries = ref.watch(siteEntryProvider);
+    // Reconcile page/selection bookkeeping outside build, so setState is legal
+    // and the always-mounted viewer survives an invalidate without resetting
+    // its scroll position or pointing the menu at a deleted record.
+    ref.listen(siteEntryProvider, (_, next) {
+      next.whenData(_reconcile);
+    });
     return Scaffold(
       appBar: AppBar(
         title: const Text("Sites"),
@@ -102,34 +108,19 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
         child: Center(
           child: siteEntries.when(data: (siteEntries) {
             if (siteEntries.isEmpty) {
-              setState(() {
-                _isVisible = false;
-                _siteId = null;
-              });
               return EmptySite(isButtonVisible: !_isSearching);
-            } else {
-              int siteSize = siteEntries.length;
-              setState(() {
-                if (siteSize >= 2) {
-                  _isVisible = true;
-                } else {
-                  _isVisible = false;
-                }
-                _pageNav.pageCounts = siteSize;
-                _pageNav.updatePageController();
-              });
-              return SitePages(
-                siteEntries: siteEntries,
-                pageNav: _pageNav,
-                isNavButtonVisible: _isVisible,
-                onPageChanged: (index) {
-                  setState(() {
-                    _siteId = siteEntries[index].id;
-                    _updatePageNav(index);
-                  });
-                },
-              );
             }
+            return SitePages(
+              siteEntries: siteEntries,
+              pageNav: _pageNav,
+              isNavButtonVisible: _isVisible,
+              onPageChanged: (index) {
+                setState(() {
+                  _siteId = siteEntries[index].id;
+                  _updatePageNav(index);
+                });
+              },
+            );
           }, loading: () {
             return const CommonProgressIndicator();
           }, error: (error, stackTrace) {
@@ -143,6 +134,25 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
             pageNav: _pageNav,
           )),
     );
+  }
+
+  void _reconcile(List<SiteData> siteEntries) {
+    if (!mounted) return;
+    final count = siteEntries.length;
+    final index = _pageNav.clampToCount(count);
+    setState(() {
+      _isVisible = count >= 2;
+      if (count == 0) {
+        _siteId = null;
+      } else if (_siteId != null &&
+          !siteEntries.any((site) => site.id == _siteId)) {
+        // The selected record was deleted; fall back to the clamped page.
+        _siteId = siteEntries[index].id;
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _pageNav.clampController(index);
+    });
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/sites/site_view.dart
+++ b/lib/screens/sites/site_view.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/fields.dart';
 import 'package:nahpu/screens/shared/forms.dart';
-import 'package:nahpu/screens/shared/layout.dart';
 import 'package:nahpu/services/navigation_services.dart';
 import 'package:nahpu/services/types/controllers.dart';
 import 'package:nahpu/services/providers/sites.dart';
@@ -45,8 +44,7 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
   @override
   Widget build(BuildContext context) {
     final siteEntries = ref.watch(siteEntryProvider);
-    return FalseWillPop(
-        child: Scaffold(
+    return Scaffold(
       appBar: AppBar(
         title: const Text("Sites"),
         automaticallyImplyLeading: false,
@@ -91,10 +89,6 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
                       _isSearching = false;
                       _searchController.clear();
                       ref.invalidate(siteEntryProvider);
-                      Navigator.pushReplacement(
-                          context,
-                          MaterialPageRoute(
-                              builder: (context) => super.widget));
                     });
                   },
                   child: const Text('Cancel')),
@@ -148,7 +142,7 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
           child: PageNavButton(
             pageNav: _pageNav,
           )),
-    ));
+    );
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/sites/site_view.dart
+++ b/lib/screens/sites/site_view.dart
@@ -4,6 +4,7 @@ import 'package:nahpu/screens/shared/fields.dart';
 import 'package:nahpu/screens/shared/forms.dart';
 import 'package:nahpu/services/navigation_services.dart';
 import 'package:nahpu/services/types/controllers.dart';
+import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/services/providers/sites.dart';
 import 'package:nahpu/screens/shared/common.dart';
 import 'package:nahpu/screens/shared/navigation.dart';
@@ -25,6 +26,7 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
   final PageNavigation _pageNav = PageNavigation.init();
   final TextEditingController _searchController = TextEditingController();
   int? _siteId;
+  bool _loadedOnce = false;
   bool _isSearching = false;
   late FocusNode _focus;
 
@@ -139,21 +141,51 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
   void _reconcile(List<SiteData> siteEntries) {
     if (!mounted) return;
     final count = siteEntries.length;
+    final landIndex = _landingIndex(siteEntries);
+    if (landIndex != null) {
+      _pageNav.currentPage = landIndex + 1;
+    }
     final index = _pageNav.clampToCount(count);
     setState(() {
       _isVisible = count >= 2;
       if (count == 0) {
         _siteId = null;
-      } else if (_siteId == null ||
+      } else if (landIndex != null ||
+          _siteId == null ||
           !siteEntries.any((site) => site.id == _siteId)) {
-        // No selection yet (first load) or the selected record was deleted;
-        // point the menu at the visible page.
+        // Landed on a one-shot target, no selection yet, or the selected
+        // record was deleted; point the menu at the visible page.
         _siteId = siteEntries[index].id;
       }
     });
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _pageNav.clampController(index);
-    });
+    if (landIndex != null) {
+      _pageNav.openControllerAt(index);
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _pageNav.clampController(index);
+      });
+    }
+  }
+
+  /// One-shot landing target for this refresh: a just-created record once it
+  /// appears in the list, or the last record on this State's first data load
+  /// (the old push-a-fresh-viewer-per-tab flow always landed at the end).
+  int? _landingIndex(List<SiteData> siteEntries) {
+    final firstLoad = !_loadedOnce;
+    _loadedOnce = true;
+    final pendingJump = ref.read(pendingRecordJumpProvider(RecordViewer.site));
+    if (pendingJump != null) {
+      final target = siteEntries.indexWhere((site) => site.id == pendingJump);
+      if (target != -1) {
+        ref.read(pendingRecordJumpProvider(RecordViewer.site).notifier).state =
+            null;
+        return target;
+      }
+    }
+    if (firstLoad && siteEntries.isNotEmpty) {
+      return siteEntries.length - 1;
+    }
+    return null;
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/sites/site_view.dart
+++ b/lib/screens/sites/site_view.dart
@@ -50,6 +50,10 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
     // and the always-mounted viewer survives an invalidate without resetting
     // its scroll position or pointing the menu at a deleted record.
     ref.listen(siteEntryProvider, (_, next) {
+      // Skip refresh emissions: an in-progress refresh still carries the
+      // previous list, and reconciling against it would consume landing
+      // requests with stale data.
+      if (next.isLoading) return;
       next.whenData(_reconcile);
     });
     return Scaffold(
@@ -158,13 +162,12 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
         _siteId = siteEntries[index].id;
       }
     });
-    if (landIndex != null && !_pageNav.pageController.hasClients) {
-      // First attach: a fresh controller opens the PageView directly on the
-      // target page (initialPage only applies to a newly created position).
+    if (landIndex != null) {
+      // The PageView is keyed by the controller, so this rebuilds it with a
+      // fresh scroll position that starts exactly on the target page — a
+      // jump on the live controller would race the refreshed list's layout.
       _pageNav.openControllerAt(index);
     } else {
-      // Attached PageView: a controller swap would re-attach the existing
-      // scroll position unchanged, so jump after the rebuilt frame instead.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _pageNav.clampController(index);
       });
@@ -218,6 +221,10 @@ class SitePages extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
+      // Keyed by controller identity: openControllerAt swaps the controller
+      // to land on a page, and the new element's fresh scroll position is
+      // what makes initialPage take effect.
+      key: ObjectKey(pageNav.pageController),
       controller: pageNav.pageController,
       itemCount: siteEntries.length,
       itemBuilder: (context, index) {

--- a/lib/screens/sites/site_view.dart
+++ b/lib/screens/sites/site_view.dart
@@ -144,9 +144,10 @@ class SiteViewerState extends ConsumerState<SiteViewer> {
       _isVisible = count >= 2;
       if (count == 0) {
         _siteId = null;
-      } else if (_siteId != null &&
+      } else if (_siteId == null ||
           !siteEntries.any((site) => site.id == _siteId)) {
-        // The selected record was deleted; fall back to the clamped page.
+        // No selection yet (first load) or the selected record was deleted;
+        // point the menu at the visible page.
         _siteId = siteEntries[index].id;
       }
     });

--- a/lib/screens/specimens/shared/menu_bar.dart
+++ b/lib/screens/specimens/shared/menu_bar.dart
@@ -10,8 +10,7 @@ import 'package:nahpu/services/specimen_services.dart';
 
 Future<void> createNewSpecimens(BuildContext context, WidgetRef ref) async {
   final newUuid = await SpecimenServices(ref: ref).createSpecimen();
-  // SpecimenViewer stays mounted in ProjectShell; refresh it in place and
-  // land on the new specimen once it appears in the refreshed list.
+  // Refresh the always-mounted viewer in place and land on the new specimen.
   ref.read(pendingRecordJumpProvider(RecordViewer.specimen).notifier).state =
       newUuid;
   ref.invalidate(specimenEntryProvider);

--- a/lib/screens/specimens/shared/menu_bar.dart
+++ b/lib/screens/specimens/shared/menu_bar.dart
@@ -3,13 +3,17 @@ import 'package:nahpu/services/types/specimens.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
+import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/providers/specimens.dart';
 import 'package:nahpu/services/specimen_services.dart';
 
 Future<void> createNewSpecimens(BuildContext context, WidgetRef ref) async {
-  await SpecimenServices(ref: ref).createSpecimen();
-  // SpecimenViewer stays mounted in ProjectShell; refresh it in place.
+  final newUuid = await SpecimenServices(ref: ref).createSpecimen();
+  // SpecimenViewer stays mounted in ProjectShell; refresh it in place and
+  // land on the new specimen once it appears in the refreshed list.
+  ref.read(pendingRecordJumpProvider(RecordViewer.specimen).notifier).state =
+      newUuid;
   ref.invalidate(specimenEntryProvider);
 }
 
@@ -125,8 +129,13 @@ class SpecimenMenuState extends ConsumerState<SpecimenMenu> {
 
   Future<void> _duplicatePart() async {
     try {
-      await SpecimenServices(ref: ref)
+      final newUuid = await SpecimenServices(ref: ref)
           .createSpecimenDuplicatePart(widget.specimenUuid!);
+      if (newUuid != null) {
+        ref
+            .read(pendingRecordJumpProvider(RecordViewer.specimen).notifier)
+            .state = newUuid;
+      }
       ref.invalidate(specimenEntryProvider);
     } catch (e) {
       if (context.mounted) {

--- a/lib/screens/specimens/shared/menu_bar.dart
+++ b/lib/screens/specimens/shared/menu_bar.dart
@@ -3,17 +3,14 @@ import 'package:nahpu/services/types/specimens.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/buttons.dart';
 import 'package:nahpu/screens/shared/forms.dart';
-import 'package:nahpu/screens/specimens/specimen_view.dart';
 import 'package:nahpu/services/providers/projects.dart';
+import 'package:nahpu/services/providers/specimens.dart';
 import 'package:nahpu/services/specimen_services.dart';
 
 Future<void> createNewSpecimens(BuildContext context, WidgetRef ref) async {
   await SpecimenServices(ref: ref).createSpecimen();
-  if (context.mounted) {
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => const SpecimenViewer()),
-    );
-  }
+  // SpecimenViewer stays mounted in ProjectShell; refresh it in place.
+  ref.invalidate(specimenEntryProvider);
 }
 
 class NewSpecimensTextButton extends ConsumerStatefulWidget {
@@ -130,20 +127,12 @@ class SpecimenMenuState extends ConsumerState<SpecimenMenu> {
     try {
       await SpecimenServices(ref: ref)
           .createSpecimenDuplicatePart(widget.specimenUuid!);
-      if (context.mounted) {
-        _navigateToSpecimenViewer();
-      }
+      ref.invalidate(specimenEntryProvider);
     } catch (e) {
       if (context.mounted) {
         _showError('Error duplicating part: $e');
       }
     }
-  }
-
-  void _navigateToSpecimenViewer() {
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(builder: (_) => const SpecimenViewer()),
-    );
   }
 
   void _showError(String message) {
@@ -170,8 +159,8 @@ class SpecimenMenuState extends ConsumerState<SpecimenMenu> {
             );
             if (context.mounted) {
               _pop();
-              _navigateToSpecimenViewer();
             }
+            ref.invalidate(specimenEntryProvider);
           } catch (e) {
             if (context.mounted) {
               _showError('Error deleting specimen: $e');

--- a/lib/screens/specimens/shared/search.dart
+++ b/lib/screens/specimens/shared/search.dart
@@ -89,15 +89,17 @@ class SpecimenSearchViewState extends ConsumerState<SpecimenSearchView> {
                       SpecimenSearchOption.values[_selectedSearchValue],
                 ).search(query.toLowerCase());
                 setState(() {
-                  if (_filteredSpecimenData.length > 2) {
-                    _isVisible = true;
-                  }
                   if (_searchController.text.isEmpty) {
                     _filteredSpecimenData.clear();
                   }
-                  _pageNav.pageCounts = _filteredSpecimenData.length;
-                  _pageNav.updatePageController();
+                  // Reuse the single PageController (no recreate/leak); clamp
+                  // the page into the new result range and jump to it.
+                  final index =
+                      _pageNav.clampToCount(_filteredSpecimenData.length);
                   _isVisible = query.isNotEmpty;
+                  WidgetsBinding.instance.addPostFrameCallback((_) {
+                    if (mounted) _pageNav.clampController(index);
+                  });
                 });
               },
             ),

--- a/lib/screens/specimens/shared/search.dart
+++ b/lib/screens/specimens/shared/search.dart
@@ -103,14 +103,11 @@ class SpecimenSearchViewState extends ConsumerState<SpecimenSearchView> {
             ),
             TextButton(
                 onPressed: () {
-                  setState(() {
-                    _searchController.clear();
-                    ref.invalidate(specimenEntryProvider);
-                    Navigator.pushReplacement(
-                        context,
-                        MaterialPageRoute(
-                            builder: (context) => const SpecimenViewer()));
-                  });
+                  _searchController.clear();
+                  ref.invalidate(specimenEntryProvider);
+                  // Return to the SpecimenViewer that is still mounted in the
+                  // ProjectShell underneath this search screen.
+                  Navigator.pop(context);
                 },
                 child: const Text('Cancel')),
           ],

--- a/lib/screens/specimens/shared/search.dart
+++ b/lib/screens/specimens/shared/search.dart
@@ -134,7 +134,6 @@ class SpecimenSearchViewState extends ConsumerState<SpecimenSearchView> {
             pageNav: _pageNav,
           ),
         ),
-        bottomNavigationBar: const ProjectBottomNavbar(),
       ),
     );
   }

--- a/lib/screens/specimens/shared/search.dart
+++ b/lib/screens/specimens/shared/search.dart
@@ -107,8 +107,7 @@ class SpecimenSearchViewState extends ConsumerState<SpecimenSearchView> {
                 onPressed: () {
                   _searchController.clear();
                   ref.invalidate(specimenEntryProvider);
-                  // Return to the SpecimenViewer that is still mounted in the
-                  // ProjectShell underneath this search screen.
+                  // Return to the still-mounted viewer below this screen.
                   Navigator.pop(context);
                 },
                 child: const Text('Cancel')),

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -45,6 +45,10 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
 
   @override
   Widget build(BuildContext context) {
+    // Reconcile page/selection bookkeeping outside build (see site_view.dart).
+    ref.listen(specimenEntryProvider, (_, next) {
+      next.whenData(_reconcile);
+    });
     return Scaffold(
       appBar: AppBar(
         title: const Text(
@@ -80,37 +84,21 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
         child: ref.watch(specimenEntryProvider).when(
               data: (specimenEntry) {
                 if (specimenEntry.isEmpty) {
-                  setState(() {
-                    isVisible = false;
-                    _specimenUuid = null;
-                  });
-
                   return const EmptySpecimen(isButtonVisible: true);
-                } else {
-                  int specimenSize = specimenEntry.length;
-                  setState(() {
-                    if (specimenSize >= 2) {
-                      isVisible = true;
-                    } else {
-                      isVisible = false;
-                    }
-                    _pageNav.pageCounts = specimenSize;
-                    _pageNav.updatePageController();
-                  });
-                  return SpecimenPages(
-                    pageNav: _pageNav,
-                    isNavButtonVisible: isVisible,
-                    specimenEntry: specimenEntry,
-                    onPageChanged: (index) {
-                      setState(() {
-                        _specimenUuid = specimenEntry[index].uuid;
-                        _catalogFmt = matchTaxonGroupToCatFmt(
-                            specimenEntry[index].taxonGroup);
-                        _updatePageNav(index);
-                      });
-                    },
-                  );
                 }
+                return SpecimenPages(
+                  pageNav: _pageNav,
+                  isNavButtonVisible: isVisible,
+                  specimenEntry: specimenEntry,
+                  onPageChanged: (index) {
+                    setState(() {
+                      _specimenUuid = specimenEntry[index].uuid;
+                      _catalogFmt = matchTaxonGroupToCatFmt(
+                          specimenEntry[index].taxonGroup);
+                      _updatePageNav(index);
+                    });
+                  },
+                );
               },
               loading: () => const CommonProgressIndicator(),
               error: (error, stack) => Text(error.toString()),
@@ -123,6 +111,26 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
         ),
       ),
     );
+  }
+
+  void _reconcile(List<SpecimenData> specimenEntry) {
+    if (!mounted) return;
+    final count = specimenEntry.length;
+    final index = _pageNav.clampToCount(count);
+    setState(() {
+      isVisible = count >= 2;
+      if (count == 0) {
+        _specimenUuid = null;
+        _catalogFmt = null;
+      } else if (_specimenUuid != null &&
+          !specimenEntry.any((specimen) => specimen.uuid == _specimenUuid)) {
+        _specimenUuid = specimenEntry[index].uuid;
+        _catalogFmt = matchTaxonGroupToCatFmt(specimenEntry[index].taxonGroup);
+      }
+    });
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _pageNav.clampController(index);
+    });
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:nahpu/screens/shared/features.dart';
 import 'package:nahpu/screens/shared/forms.dart';
-import 'package:nahpu/screens/shared/layout.dart';
 import 'package:nahpu/screens/specimens/shared/search.dart';
 import 'package:nahpu/services/specimen_services.dart';
 import 'package:nahpu/services/taxonomy_services.dart';
@@ -46,8 +45,7 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
 
   @override
   Widget build(BuildContext context) {
-    return FalseWillPop(
-        child: Scaffold(
+    return Scaffold(
       appBar: AppBar(
         title: const Text(
           "Specimen Records",
@@ -60,7 +58,9 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
                     final specimenData =
                         await SpecimenServices(ref: ref).getAllSpecimens();
                     if (context.mounted) {
-                      Navigator.of(context).pushReplacement(MaterialPageRoute(
+                      // Push the search screen on top of the shell; its Cancel
+                      // button pops back to this still-mounted viewer.
+                      Navigator.of(context).push(MaterialPageRoute(
                         builder: (context) =>
                             SpecimenSearchView(specimenData: specimenData),
                       ));
@@ -122,7 +122,7 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
           pageNav: _pageNav,
         ),
       ),
-    ));
+    );
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -49,8 +49,7 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
   Widget build(BuildContext context) {
     // Reconcile page/selection bookkeeping outside build (see site_view.dart).
     ref.listen(specimenEntryProvider, (_, next) {
-      // Skip refresh emissions: an in-progress refresh still carries the
-      // previous list (see site_view.dart).
+      // Skip refresh emissions (see site_view.dart).
       if (next.isLoading) return;
       next.whenData(_reconcile);
     });
@@ -67,8 +66,7 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
                     final specimenData =
                         await SpecimenServices(ref: ref).getAllSpecimens();
                     if (context.mounted) {
-                      // Push the search screen on top of the shell; its Cancel
-                      // button pops back to this still-mounted viewer.
+                      // Pushed on top of the shell; Cancel pops back here.
                       Navigator.of(context).push(MaterialPageRoute(
                         builder: (context) =>
                             SpecimenSearchView(specimenData: specimenData),
@@ -139,9 +137,7 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
       }
     });
     if (landIndex != null) {
-      // The PageView is keyed by the controller, so this rebuilds it with a
-      // fresh scroll position that starts exactly on the target page — a
-      // jump on the live controller would race the refreshed list's layout.
+      // Keyed controller swap (see site_view.dart).
       _pageNav.openControllerAt(index);
     } else {
       WidgetsBinding.instance.addPostFrameCallback((_) {
@@ -150,9 +146,7 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
     }
   }
 
-  /// One-shot landing target for this refresh: a just-created record once it
-  /// appears in the list, or the last record on this State's first data load
-  /// (the old push-a-fresh-viewer-per-tab flow always landed at the end).
+  /// One-shot landing target for this refresh (see site_view.dart).
   int? _landingIndex(List<SpecimenData> specimenEntry) {
     final firstLoad = !_loadedOnce;
     _loadedOnce = true;
@@ -240,8 +234,7 @@ class SpecimenPages extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
-      // Keyed by controller identity so openControllerAt lands on its page
-      // via a fresh scroll position (see site_view.dart).
+      // Keyed by controller identity (see site_view.dart).
       key: ObjectKey(pageNav.pageController),
       controller: pageNav.pageController,
       itemCount: specimenEntry.length,

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -49,6 +49,9 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
   Widget build(BuildContext context) {
     // Reconcile page/selection bookkeeping outside build (see site_view.dart).
     ref.listen(specimenEntryProvider, (_, next) {
+      // Skip refresh emissions: an in-progress refresh still carries the
+      // previous list (see site_view.dart).
+      if (next.isLoading) return;
       next.whenData(_reconcile);
     });
     return Scaffold(
@@ -135,13 +138,12 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
         _catalogFmt = matchTaxonGroupToCatFmt(specimenEntry[index].taxonGroup);
       }
     });
-    if (landIndex != null && !_pageNav.pageController.hasClients) {
-      // First attach: a fresh controller opens the PageView directly on the
-      // target page (initialPage only applies to a newly created position).
+    if (landIndex != null) {
+      // The PageView is keyed by the controller, so this rebuilds it with a
+      // fresh scroll position that starts exactly on the target page — a
+      // jump on the live controller would race the refreshed list's layout.
       _pageNav.openControllerAt(index);
     } else {
-      // Attached PageView: a controller swap would re-attach the existing
-      // scroll position unchanged, so jump after the rebuilt frame instead.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _pageNav.clampController(index);
       });
@@ -238,6 +240,9 @@ class SpecimenPages extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PageView.builder(
+      // Keyed by controller identity so openControllerAt lands on its page
+      // via a fresh scroll position (see site_view.dart).
+      key: ObjectKey(pageNav.pageController),
       controller: pageNav.pageController,
       itemCount: specimenEntry.length,
       itemBuilder: (context, index) {

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -122,7 +122,6 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
           pageNav: _pageNav,
         ),
       ),
-      bottomNavigationBar: const ProjectBottomNavbar(),
     ));
   }
 

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -122,7 +122,7 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
       if (count == 0) {
         _specimenUuid = null;
         _catalogFmt = null;
-      } else if (_specimenUuid != null &&
+      } else if (_specimenUuid == null ||
           !specimenEntry.any((specimen) => specimen.uuid == _specimenUuid)) {
         _specimenUuid = specimenEntry[index].uuid;
         _catalogFmt = matchTaxonGroupToCatFmt(specimenEntry[index].taxonGroup);

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -7,6 +7,7 @@ import 'package:nahpu/services/specimen_services.dart';
 import 'package:nahpu/services/taxonomy_services.dart';
 import 'package:nahpu/services/types/controllers.dart';
 import 'package:nahpu/services/types/specimens.dart';
+import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/services/providers/specimens.dart';
 import 'package:nahpu/screens/shared/common.dart';
 import 'package:nahpu/screens/shared/navigation.dart';
@@ -26,6 +27,7 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
   bool isVisible = false;
   final PageNavigation _pageNav = PageNavigation.init();
   String? _specimenUuid;
+  bool _loadedOnce = false;
   CatalogFmt? _catalogFmt;
   TaxonData taxonomy = TaxonData();
   late FocusNode _focus;
@@ -116,21 +118,54 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
   void _reconcile(List<SpecimenData> specimenEntry) {
     if (!mounted) return;
     final count = specimenEntry.length;
+    final landIndex = _landingIndex(specimenEntry);
+    if (landIndex != null) {
+      _pageNav.currentPage = landIndex + 1;
+    }
     final index = _pageNav.clampToCount(count);
     setState(() {
       isVisible = count >= 2;
       if (count == 0) {
         _specimenUuid = null;
         _catalogFmt = null;
-      } else if (_specimenUuid == null ||
+      } else if (landIndex != null ||
+          _specimenUuid == null ||
           !specimenEntry.any((specimen) => specimen.uuid == _specimenUuid)) {
         _specimenUuid = specimenEntry[index].uuid;
         _catalogFmt = matchTaxonGroupToCatFmt(specimenEntry[index].taxonGroup);
       }
     });
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) _pageNav.clampController(index);
-    });
+    if (landIndex != null) {
+      _pageNav.openControllerAt(index);
+    } else {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _pageNav.clampController(index);
+      });
+    }
+  }
+
+  /// One-shot landing target for this refresh: a just-created record once it
+  /// appears in the list, or the last record on this State's first data load
+  /// (the old push-a-fresh-viewer-per-tab flow always landed at the end).
+  int? _landingIndex(List<SpecimenData> specimenEntry) {
+    final firstLoad = !_loadedOnce;
+    _loadedOnce = true;
+    final pendingJump =
+        ref.read(pendingRecordJumpProvider(RecordViewer.specimen));
+    if (pendingJump != null) {
+      final target =
+          specimenEntry.indexWhere((specimen) => specimen.uuid == pendingJump);
+      if (target != -1) {
+        ref
+            .read(pendingRecordJumpProvider(RecordViewer.specimen).notifier)
+            .state = null;
+        return target;
+      }
+    }
+    if (firstLoad && specimenEntry.isNotEmpty) {
+      return specimenEntry.length - 1;
+    }
+    return null;
   }
 
   void _updatePageNav(int value) {

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -135,9 +135,13 @@ class SpecimenViewerState extends ConsumerState<SpecimenViewer> {
         _catalogFmt = matchTaxonGroupToCatFmt(specimenEntry[index].taxonGroup);
       }
     });
-    if (landIndex != null) {
+    if (landIndex != null && !_pageNav.pageController.hasClients) {
+      // First attach: a fresh controller opens the PageView directly on the
+      // target page (initialPage only applies to a newly created position).
       _pageNav.openControllerAt(index);
     } else {
+      // Attached PageView: a controller swap would re-attach the existing
+      // scroll position unchanged, so jump after the rebuilt frame instead.
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) _pageNav.clampController(index);
       });

--- a/lib/services/collevent_services.dart
+++ b/lib/services/collevent_services.dart
@@ -192,12 +192,13 @@ class EventDuplicateService extends AppServices {
   CollEventServices get collEventServices => CollEventServices(ref: ref);
 
   /// We duplicate most of the data from the origin event
-  Future<void> duplicate(int originEventID) async {
+  /// Returns the new event's id, or null when the origin no longer exists.
+  Future<int?> duplicate(int originEventID) async {
     CollEventData? collEventData =
         await collEventServices.getCollEvent(originEventID);
 
     if (collEventData == null) {
-      return;
+      return null;
     }
     String newStartDate = _incrementDate(collEventData.startDate ?? '') ?? '';
     String newEndDate = _incrementDate(collEventData.endDate ?? '') ?? '';
@@ -217,6 +218,7 @@ class EventDuplicateService extends AppServices {
     await _duplicateCollPersonnel(originEventID, destinationEventId);
     collEventServices.createWeatherData(destinationEventId);
     collEventServices.invalidateCollEvent();
+    return destinationEventId;
   }
 
   Future<void> _duplicateCollEffort(

--- a/lib/services/navigation_services.dart
+++ b/lib/services/navigation_services.dart
@@ -76,13 +76,14 @@ class PageNavigation {
 
   /// Replaces [pageController] with a fresh one opened at [index].
   ///
-  /// Used when landing on a specific page of a list that is about to be
-  /// rebuilt (first load, or a create/duplicate that grew the list). A plain
-  /// [clampController] jump can race the rebuild — the data listener runs
-  /// before the [PageView] picks up the larger item count — whereas a
-  /// controller whose `initialPage` is already [index] attaches there
-  /// directly. The previous controller is disposed once the rebuild has
-  /// detached it from its old [PageView].
+  /// Only effective while no [PageView] is attached (first load, or a list
+  /// that was empty): `initialPage` is applied when the [PageView] creates
+  /// its scroll position, so the view opens directly on the target page. An
+  /// already-attached [PageView] re-attaches a swapped-in controller to its
+  /// existing scroll position — `initialPage` is ignored and the viewport
+  /// does not move — so callers must [clampController] from a post-frame
+  /// callback instead. The previous controller is disposed once the rebuild
+  /// has detached it.
   void openControllerAt(int index) {
     final previous = pageController;
     pageController = PageController(initialPage: index);

--- a/lib/services/navigation_services.dart
+++ b/lib/services/navigation_services.dart
@@ -73,9 +73,13 @@ class PageNavigation {
 
   /// Jumps the live [PageController] to [index] if it isn't already there.
   /// Never jumps past the laid-out extent — that clamps to the old last page
-  /// and corrupts the bookkeeping via a spurious onPageChanged.
+  /// and corrupts the bookkeeping via a spurious onPageChanged. Skipped while
+  /// the viewport is scrolling: a jump would cut short a multi-page animation
+  /// (the first/last-page buttons), and the settling onPageChanged reconciles
+  /// again anyway.
   void clampController(int index) {
     if (pageController.hasClients &&
+        !pageController.position.isScrollingNotifier.value &&
         _canReach(index) &&
         (pageController.page?.round() ?? 0) != index) {
       pageController.jumpToPage(index);

--- a/lib/services/navigation_services.dart
+++ b/lib/services/navigation_services.dart
@@ -65,10 +65,25 @@ class PageNavigation {
     return currentPage - 1;
   }
 
+  /// Whether the attached viewport can currently reach [index]. False while
+  /// the [PageView] still has the pre-refresh (smaller) item count laid out.
+  bool _canReach(int index) {
+    final position = pageController.position;
+    if (!position.hasContentDimensions) return false;
+    final pageSize =
+        position.viewportDimension * pageController.viewportFraction;
+    if (pageSize <= 0) return false;
+    // Tolerance absorbs floating-point error in the extent math.
+    return index * pageSize <= position.maxScrollExtent + 0.001;
+  }
+
   /// Jumps the live [PageController] to [index] if it isn't already there.
-  /// Safe to call from a post-frame callback after the list shrinks.
+  /// Safe to call from a post-frame callback after the list shrinks. Never
+  /// jumps to a page the laid-out extent cannot reach — that clamps to the
+  /// old last page and corrupts the bookkeeping via a spurious onPageChanged.
   void clampController(int index) {
     if (pageController.hasClients &&
+        _canReach(index) &&
         (pageController.page?.round() ?? 0) != index) {
       pageController.jumpToPage(index);
     }
@@ -76,17 +91,20 @@ class PageNavigation {
 
   /// Replaces [pageController] with a fresh one opened at [index].
   ///
-  /// Only effective while no [PageView] is attached (first load, or a list
-  /// that was empty): `initialPage` is applied when the [PageView] creates
-  /// its scroll position, so the view opens directly on the target page. An
-  /// already-attached [PageView] re-attaches a swapped-in controller to its
-  /// existing scroll position — `initialPage` is ignored and the viewport
-  /// does not move — so callers must [clampController] from a post-frame
-  /// callback instead. The previous controller is disposed once the rebuild
-  /// has detached it.
+  /// `initialPage` is only applied when a [PageView] creates its scroll
+  /// position, so the viewer's [PageView] must be keyed by the controller
+  /// instance (`ObjectKey(pageNav.pageController)`): the swap then rebuilds
+  /// it as a new element whose fresh position starts exactly on the target
+  /// page, with no `onPageChanged` fired. Jumping the live controller
+  /// instead is unreliable here — a landing is requested by a data listener
+  /// while the refreshed (grown) list may not be laid out yet, and a jump
+  /// against the stale extent clamps to the old last page and corrupts the
+  /// page bookkeeping via a spurious `onPageChanged`. `keepPage: false`
+  /// stops [PageStorage] from restoring the pre-landing page. The previous
+  /// controller is disposed once the rebuild has detached it.
   void openControllerAt(int index) {
     final previous = pageController;
-    pageController = PageController(initialPage: index);
+    pageController = PageController(initialPage: index, keepPage: false);
     _disposeWhenDetached(previous);
   }
 

--- a/lib/services/navigation_services.dart
+++ b/lib/services/navigation_services.dart
@@ -74,6 +74,32 @@ class PageNavigation {
     }
   }
 
+  /// Replaces [pageController] with a fresh one opened at [index].
+  ///
+  /// Used when landing on a specific page of a list that is about to be
+  /// rebuilt (first load, or a create/duplicate that grew the list). A plain
+  /// [clampController] jump can race the rebuild — the data listener runs
+  /// before the [PageView] picks up the larger item count — whereas a
+  /// controller whose `initialPage` is already [index] attaches there
+  /// directly. The previous controller is disposed once the rebuild has
+  /// detached it from its old [PageView].
+  void openControllerAt(int index) {
+    final previous = pageController;
+    pageController = PageController(initialPage: index);
+    _disposeWhenDetached(previous);
+  }
+
+  void _disposeWhenDetached(PageController controller) {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (controller.hasClients) {
+        // The rebuild that swaps in the new controller hasn't run yet; retry.
+        _disposeWhenDetached(controller);
+      } else {
+        controller.dispose();
+      }
+    });
+  }
+
   void dispose() {
     pageController.dispose();
   }

--- a/lib/services/navigation_services.dart
+++ b/lib/services/navigation_services.dart
@@ -37,11 +37,41 @@ class PageNavigation {
     }
   }
 
-  void updatePageController() {
-    pageController = PageController(
-      initialPage: pageCounts + 1,
-      keepPage: false,
-    );
+  /// Reconciles the page bookkeeping after the underlying list changes
+  /// (create/delete/search). Updates [pageCounts], clamps [currentPage] into
+  /// the new range, recomputes the first/last flags, and returns the 0-based
+  /// index that should be shown (0 when the list is empty).
+  ///
+  /// This replaces the old `updatePageController()`, which rebuilt the
+  /// [PageController] on every data refresh (leaking controllers and resetting
+  /// the view to the end). The controller created in [PageNavigation.init] now
+  /// lives for the State's lifetime; callers move to the clamped page via
+  /// [clampController] from a post-frame callback instead.
+  int clampToCount(int count) {
+    pageCounts = count;
+    if (count == 0) {
+      // Empty list: no page is first or last, and the nav bar is hidden.
+      currentPage = 0;
+      isFirstPage = false;
+      isLastPage = false;
+      return 0;
+    }
+    if (currentPage < 1) {
+      currentPage = 1;
+    } else if (currentPage > count) {
+      currentPage = count;
+    }
+    updatePageNavigation();
+    return currentPage - 1;
+  }
+
+  /// Jumps the live [PageController] to [index] if it isn't already there.
+  /// Safe to call from a post-frame callback after the list shrinks.
+  void clampController(int index) {
+    if (pageController.hasClients &&
+        (pageController.page?.round() ?? 0) != index) {
+      pageController.jumpToPage(index);
+    }
   }
 
   void dispose() {

--- a/lib/services/navigation_services.dart
+++ b/lib/services/navigation_services.dart
@@ -37,16 +37,10 @@ class PageNavigation {
     }
   }
 
-  /// Reconciles the page bookkeeping after the underlying list changes
-  /// (create/delete/search). Updates [pageCounts], clamps [currentPage] into
-  /// the new range, recomputes the first/last flags, and returns the 0-based
-  /// index that should be shown (0 when the list is empty).
-  ///
-  /// This replaces the old `updatePageController()`, which rebuilt the
-  /// [PageController] on every data refresh (leaking controllers and resetting
-  /// the view to the end). The controller created in [PageNavigation.init] now
-  /// lives for the State's lifetime; callers move to the clamped page via
-  /// [clampController] from a post-frame callback instead.
+  /// Reconciles page bookkeeping after the list changes: updates [pageCounts],
+  /// clamps [currentPage], and returns the 0-based index to show (0 when
+  /// empty). Leaves [pageController] alone — callers move to the clamped page
+  /// via [clampController] from a post-frame callback.
   int clampToCount(int count) {
     pageCounts = count;
     if (count == 0) {
@@ -78,9 +72,8 @@ class PageNavigation {
   }
 
   /// Jumps the live [PageController] to [index] if it isn't already there.
-  /// Safe to call from a post-frame callback after the list shrinks. Never
-  /// jumps to a page the laid-out extent cannot reach — that clamps to the
-  /// old last page and corrupts the bookkeeping via a spurious onPageChanged.
+  /// Never jumps past the laid-out extent — that clamps to the old last page
+  /// and corrupts the bookkeeping via a spurious onPageChanged.
   void clampController(int index) {
     if (pageController.hasClients &&
         _canReach(index) &&
@@ -91,17 +84,12 @@ class PageNavigation {
 
   /// Replaces [pageController] with a fresh one opened at [index].
   ///
-  /// `initialPage` is only applied when a [PageView] creates its scroll
-  /// position, so the viewer's [PageView] must be keyed by the controller
-  /// instance (`ObjectKey(pageNav.pageController)`): the swap then rebuilds
-  /// it as a new element whose fresh position starts exactly on the target
-  /// page, with no `onPageChanged` fired. Jumping the live controller
-  /// instead is unreliable here — a landing is requested by a data listener
-  /// while the refreshed (grown) list may not be laid out yet, and a jump
-  /// against the stale extent clamps to the old last page and corrupts the
-  /// page bookkeeping via a spurious `onPageChanged`. `keepPage: false`
-  /// stops [PageStorage] from restoring the pre-landing page. The previous
-  /// controller is disposed once the rebuild has detached it.
+  /// `initialPage` only applies when a [PageView] creates its scroll position,
+  /// so the viewer's [PageView] must be keyed by the controller instance: the
+  /// swap rebuilds it directly on the target page, with no `onPageChanged`.
+  /// A live jump is unreliable here — the refreshed (grown) list may not be
+  /// laid out yet (see [clampController]). `keepPage: false` stops
+  /// [PageStorage] from restoring the pre-landing page.
   void openControllerAt(int index) {
     final previous = pageController;
     pageController = PageController(initialPage: index, keepPage: false);

--- a/lib/services/providers/page_jump.dart
+++ b/lib/services/providers/page_jump.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Identifies the top-level record viewers hosted by the project shell.
+enum RecordViewer { site, collEvent, specimen, narrative }
+
+/// A one-shot request for a record viewer to land on a newly created record.
+///
+/// The viewers stay mounted in the shell's `IndexedStack`, so a data refresh
+/// preserves the current page. Creating or duplicating a record is the
+/// exception: the new row is appended to the end of the list and the user
+/// expects to land on it to fill it in. The create/duplicate handlers live in
+/// the menu bars, which have no access to the viewer's page controller, so
+/// they store the new record's id (int) or uuid (String) here; the matching
+/// viewer consumes it in `_reconcile` once the record shows up in the
+/// refreshed list. Keying on the record id (rather than a boolean flag) makes
+/// the handoff immune to emission ordering: a refresh that does not contain
+/// the record yet simply leaves the request pending.
+final pendingRecordJumpProvider =
+    StateProvider.family<Object?, RecordViewer>((ref, viewer) => null);

--- a/lib/services/site_services.dart
+++ b/lib/services/site_services.dart
@@ -24,12 +24,13 @@ class SiteServices extends AppServices {
     return siteID;
   }
 
-  Future<void> duplicateSite(int originID) async {
+  /// Returns the new site's id, or null when the origin no longer exists.
+  Future<int?> duplicateSite(int originID) async {
     SiteData? siteData = await getSite(originID);
     if (siteData == null) {
-      return;
+      return null;
     }
-    int _ = await SiteQuery(dbAccess).createSite(SiteCompanion(
+    int newSiteId = await SiteQuery(dbAccess).createSite(SiteCompanion(
       projectUuid: db.Value(currentProjectUuid),
       leadStaffId: db.Value(siteData.leadStaffId),
       siteType: db.Value(siteData.siteType),
@@ -44,6 +45,7 @@ class SiteServices extends AppServices {
       habitatDescription: db.Value(siteData.habitatDescription),
     ));
     invalidateSite();
+    return newSiteId;
   }
 
   Future<SiteData?> getSite(int? id) async {

--- a/lib/services/specimen_services.dart
+++ b/lib/services/specimen_services.dart
@@ -75,11 +75,12 @@ class SpecimenServices extends AppServices {
         );
   }
 
-  Future<void> createSpecimenDuplicatePart(String specimenUuid) async {
+  /// Returns the new specimen's uuid, or null when the origin has no parts.
+  Future<String?> createSpecimenDuplicatePart(String specimenUuid) async {
     List<SpecimenPartData> partData =
         await SpecimenPartQuery(dbAccess).getSpecimenParts(specimenUuid);
     if (partData.isEmpty) {
-      return;
+      return null;
     }
     String newSpecimenUuid = await createSpecimen();
 
@@ -96,6 +97,7 @@ class SpecimenServices extends AppServices {
     }
 
     ref.invalidate(partBySpecimenProvider);
+    return newSpecimenUuid;
   }
 
   Future<List<SpecimenData>> getAllSpecimens() async {

--- a/test/action_buttons_test.dart
+++ b/test/action_buttons_test.dart
@@ -14,10 +14,9 @@ import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/providers/settings.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Regression tests for the Dashboard `+` speed dial (issue #132). Creating a
-/// record from the Dashboard must switch the shell to the tab that shows it —
-/// under the pre-fix code the insert succeeded but the shell stayed on the
-/// Dashboard, so the create looked like a no-op.
+/// Regression tests for the Dashboard `+` speed dial (issue #132): creating a
+/// record must switch the shell to the tab that shows it, not silently insert
+/// behind the Dashboard.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   const pathChannel = MethodChannel('plugins.flutter.io/path_provider');
@@ -48,9 +47,8 @@ void main() {
           name: Value('Test project'),
         ));
 
-    // The Dashboard slot carries the real ActionButtons; the Sites slot is the
-    // real SiteViewer so the test can assert the user actually sees the new
-    // record. The remaining tabs are stand-ins.
+    // Dashboard and Sites slots are real (ActionButtons / SiteViewer) so the
+    // test can assert the new record is actually shown; the rest are stand-ins.
     await tester.pumpWidget(
       UncontrolledProviderScope(
         container: container,
@@ -91,8 +89,6 @@ void main() {
     await tester.tap(find.text('Create site'));
     await tester.pumpAndSettle();
 
-    // The shell switched to the Sites tab and the viewer landed on the
-    // freshly created record — not a silent insert behind the Dashboard.
     expect(container.read(projectNavbarIndexProvider), 1);
     expect(find.text('Page 1 of 1'), findsAtLeastNWidgets(1));
     expect(tester.takeException(), isNull);

--- a/test/action_buttons_test.dart
+++ b/test/action_buttons_test.dart
@@ -1,0 +1,119 @@
+import 'package:drift/drift.dart' show DatabaseConnection, Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_speed_dial/flutter_speed_dial.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nahpu/screens/projects/components/action_buttons.dart';
+import 'package:nahpu/screens/shared/project_shell.dart';
+import 'package:nahpu/screens/sites/site_view.dart';
+import 'package:nahpu/services/database/database.dart';
+import 'package:nahpu/services/providers/database.dart';
+import 'package:nahpu/services/providers/projects.dart';
+import 'package:nahpu/services/providers/settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Regression tests for the Dashboard `+` speed dial (issue #132). Creating a
+/// record from the Dashboard must switch the shell to the tab that shows it —
+/// under the pre-fix code the insert succeeded but the shell stayed on the
+/// Dashboard, so the create looked like a no-op.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const pathChannel = MethodChannel('plugins.flutter.io/path_provider');
+  const projectUuid = 'proj-1';
+
+  setUpAll(() {
+    // SiteForm's media/coordinate components touch path_provider.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathChannel, (call) async => '/tmp');
+  });
+
+  Future<ProviderContainer> pumpShell(WidgetTester tester, Database db) async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final container = ProviderContainer(
+      overrides: [
+        databaseProvider.overrideWithValue(db),
+        settingProvider.overrideWithValue(prefs),
+      ],
+    );
+    addTearDown(container.dispose);
+    container.read(projectUuidProvider.notifier).updateProjectUuid(projectUuid);
+
+    // collEvent (unlike site) enforces its projectUuid foreign key, so the
+    // project row must exist before any create.
+    await db.into(db.project).insert(const ProjectCompanion(
+          uuid: Value(projectUuid),
+          name: Value('Test project'),
+        ));
+
+    // The Dashboard slot carries the real ActionButtons; the Sites slot is the
+    // real SiteViewer so the test can assert the user actually sees the new
+    // record. The remaining tabs are stand-ins.
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: ProjectShell(pages: [
+            Scaffold(
+              body: Text('PAGE-Dashboard'),
+              floatingActionButton: ActionButtons(),
+            ),
+            SiteViewer(),
+            Text('PAGE-Events'),
+            Text('PAGE-Specimens'),
+            Text('PAGE-Narrative'),
+          ]),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return container;
+  }
+
+  // PageViewer schedules a one-shot 5s timer to hide the page-number overlay;
+  // fire it so no timer is pending when the tree is disposed.
+  Future<void> drainOverlayTimer(WidgetTester tester) =>
+      tester.pump(const Duration(seconds: 6));
+
+  testWidgets(
+      'Dashboard + > Create site switches to the Sites tab on the new record',
+      (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+
+    final container = await pumpShell(tester, db);
+    expect(container.read(projectNavbarIndexProvider), 0);
+
+    await tester.tap(find.byType(SpeedDial));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Create site'));
+    await tester.pumpAndSettle();
+
+    // The shell switched to the Sites tab and the viewer landed on the
+    // freshly created record — not a silent insert behind the Dashboard.
+    expect(container.read(projectNavbarIndexProvider), 1);
+    expect(find.text('Page 1 of 1'), findsAtLeastNWidgets(1));
+    expect(tester.takeException(), isNull);
+
+    await drainOverlayTimer(tester);
+  });
+
+  testWidgets('Dashboard + > Create event switches to the Events tab',
+      (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+
+    final container = await pumpShell(tester, db);
+
+    await tester.tap(find.byType(SpeedDial));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Create event'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(projectNavbarIndexProvider), 2);
+    expect(find.text('PAGE-Events'), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}

--- a/test/navigation_services_test.dart
+++ b/test/navigation_services_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nahpu/services/navigation_services.dart';
+
+void main() {
+  group('PageNavigation.clampToCount', () {
+    test('first load from a fresh state shows the first page', () {
+      final nav = PageNavigation.init();
+      // currentPage starts at 0 (no page selected yet).
+      final index = nav.clampToCount(3);
+      expect(nav.pageCounts, 3);
+      expect(nav.currentPage, 1);
+      expect(index, 0); // 0-based index of the first page
+      expect(nav.isFirstPage, isTrue);
+      expect(nav.isLastPage, isFalse);
+    });
+
+    test('a page in the middle of the range is left untouched', () {
+      final nav = PageNavigation.init();
+      nav.currentPage = 2;
+      final index = nav.clampToCount(3);
+      expect(nav.currentPage, 2);
+      expect(index, 1);
+      expect(nav.isFirstPage, isFalse);
+      expect(nav.isLastPage, isFalse);
+    });
+
+    test('shrinking the list clamps currentPage to the new last page', () {
+      final nav = PageNavigation.init();
+      nav.currentPage = 5; // was on page 5 of 5
+      final index = nav.clampToCount(3); // list shrank to 3
+      expect(nav.pageCounts, 3);
+      expect(nav.currentPage, 3); // clamped to the new last page
+      expect(index, 2);
+      expect(nav.isFirstPage, isFalse);
+      expect(nav.isLastPage, isTrue);
+    });
+
+    test('an empty list resets to page 0 and shows index 0', () {
+      final nav = PageNavigation.init();
+      nav.currentPage = 4;
+      final index = nav.clampToCount(0);
+      expect(nav.pageCounts, 0);
+      expect(nav.currentPage, 0);
+      expect(index, 0);
+      expect(nav.isFirstPage, isFalse);
+      expect(nav.isLastPage, isFalse);
+    });
+
+    test('the last page sets isLastPage', () {
+      final nav = PageNavigation.init();
+      nav.currentPage = 3;
+      nav.clampToCount(3);
+      expect(nav.isFirstPage, isFalse);
+      expect(nav.isLastPage, isTrue);
+    });
+  });
+}

--- a/test/navigation_services_test.dart
+++ b/test/navigation_services_test.dart
@@ -5,7 +5,6 @@ void main() {
   group('PageNavigation.clampToCount', () {
     test('first load from a fresh state shows the first page', () {
       final nav = PageNavigation.init();
-      // currentPage starts at 0 (no page selected yet).
       final index = nav.clampToCount(3);
       expect(nav.pageCounts, 3);
       expect(nav.currentPage, 1);
@@ -26,10 +25,10 @@ void main() {
 
     test('shrinking the list clamps currentPage to the new last page', () {
       final nav = PageNavigation.init();
-      nav.currentPage = 5; // was on page 5 of 5
-      final index = nav.clampToCount(3); // list shrank to 3
+      nav.currentPage = 5;
+      final index = nav.clampToCount(3);
       expect(nav.pageCounts, 3);
-      expect(nav.currentPage, 3); // clamped to the new last page
+      expect(nav.currentPage, 3);
       expect(index, 2);
       expect(nav.isFirstPage, isFalse);
       expect(nav.isLastPage, isTrue);

--- a/test/navigation_services_test.dart
+++ b/test/navigation_services_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nahpu/services/navigation_services.dart';
 
@@ -51,6 +52,50 @@ void main() {
       nav.clampToCount(3);
       expect(nav.isFirstPage, isFalse);
       expect(nav.isLastPage, isTrue);
+    });
+  });
+
+  group('PageNavigation.clampController', () {
+    Widget buildPager(PageNavigation nav) {
+      return MaterialApp(
+        home: PageView.builder(
+          controller: nav.pageController,
+          itemCount: 10,
+          itemBuilder: (context, index) => Text('page $index'),
+        ),
+      );
+    }
+
+    testWidgets('jumps a settled viewport to the given index', (tester) async {
+      final nav = PageNavigation.init();
+      await tester.pumpWidget(buildPager(nav));
+      nav.clampController(4);
+      await tester.pumpAndSettle();
+      expect(nav.pageController.page!.round(), 4);
+      nav.dispose();
+    });
+
+    testWidgets('does not cut short an in-flight page animation',
+        (tester) async {
+      final nav = PageNavigation.init();
+      await tester.pumpWidget(buildPager(nav));
+      nav.pageController.jumpToPage(9);
+      await tester.pump();
+
+      nav.pageController.animateToPage(0,
+          duration: kTabScrollDuration, curve: Curves.easeInOut);
+      // A refresh triggered by an intermediate onPageChanged reconciles a few
+      // frames later with the page recorded back then; it must not hijack the
+      // viewport.
+      await tester.pump(kTabScrollDuration ~/ 4);
+      final staleIndex = nav.pageController.page!.round();
+      await tester.pump(kTabScrollDuration ~/ 4);
+      expect(nav.pageController.page!.round(), isNot(staleIndex));
+      nav.clampController(staleIndex);
+
+      await tester.pumpAndSettle();
+      expect(nav.pageController.page!.round(), 0);
+      nav.dispose();
     });
   });
 }

--- a/test/project_shell_test.dart
+++ b/test/project_shell_test.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nahpu/screens/shared/project_shell.dart';
+import 'package:nahpu/services/providers/projects.dart';
+import 'package:nahpu/services/providers/settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Records how many routes are pushed onto the navigator so we can assert that
+/// switching tabs does NOT push a new route (the whole point of the
+/// IndexedStack refactor — tabs swap in place instead of stacking pages).
+class _PushCountingObserver extends NavigatorObserver {
+  int pushCount = 0;
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    pushCount++;
+    super.didPush(route, previousRoute);
+  }
+}
+
+// Lightweight stand-ins for the five real project screens, which would
+// otherwise pull in the database/provider stack.
+const _pages = [
+  Text('PAGE-Dashboard'),
+  Text('PAGE-Sites'),
+  Text('PAGE-Events'),
+  Text('PAGE-Specimens'),
+  Text('PAGE-Narrative'),
+];
+
+Future<_PushCountingObserver> _pumpShell(WidgetTester tester) async {
+  SharedPreferences.setMockInitialValues({});
+  final prefs = await SharedPreferences.getInstance();
+  final observer = _PushCountingObserver();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [settingProvider.overrideWithValue(prefs)],
+      child: MaterialApp(
+        navigatorObservers: [observer],
+        home: const ProjectShell(pages: _pages),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return observer;
+}
+
+void main() {
+  testWidgets('shows the Dashboard page first', (tester) async {
+    await _pumpShell(tester);
+
+    expect(find.text('PAGE-Dashboard'), findsOneWidget);
+    expect(find.byType(IndexedStack), findsOneWidget);
+  });
+
+  testWidgets('tapping a tab swaps the page in place without pushing a route',
+      (tester) async {
+    final observer = await _pumpShell(tester);
+    final pushesAfterInitialRoute = observer.pushCount;
+
+    await tester.tap(find.text('Specimens'));
+    await tester.pumpAndSettle();
+
+    // The provider index moved to the Specimens tab...
+    final container = ProviderScope.containerOf(
+      tester.element(find.byType(IndexedStack)),
+    );
+    expect(container.read(projectNavbarIndexProvider), 3);
+
+    // ...the Specimens page is now the visible one...
+    expect(find.text('PAGE-Specimens'), findsOneWidget);
+
+    // ...and crucially, no new route was pushed (no page-transition / stacking).
+    expect(observer.pushCount, pushesAfterInitialRoute);
+  });
+
+  testWidgets('keeps every page alive in the tree across switches',
+      (tester) async {
+    await _pumpShell(tester);
+
+    await tester.tap(find.text('Narrative'));
+    await tester.pumpAndSettle();
+
+    // IndexedStack retains all children (offstage), so the Dashboard page is
+    // still mounted even though Narrative is selected — this is what preserves
+    // per-screen state across tab switches.
+    expect(
+      find.text('PAGE-Dashboard', skipOffstage: false),
+      findsOneWidget,
+    );
+    expect(find.text('PAGE-Narrative'), findsOneWidget);
+  });
+}

--- a/test/project_shell_test.dart
+++ b/test/project_shell_test.dart
@@ -6,9 +6,8 @@ import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/providers/settings.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Records how many routes are pushed onto the navigator so we can assert that
-/// switching tabs does NOT push a new route (the whole point of the
-/// IndexedStack refactor — tabs swap in place instead of stacking pages).
+/// Counts navigator pushes so tests can assert that switching tabs swaps in
+/// place instead of pushing a route.
 class _PushCountingObserver extends NavigatorObserver {
   int pushCount = 0;
 
@@ -63,16 +62,13 @@ void main() {
     await tester.tap(find.text('Specimens'));
     await tester.pumpAndSettle();
 
-    // The provider index moved to the Specimens tab...
     final container = ProviderScope.containerOf(
       tester.element(find.byType(IndexedStack)),
     );
     expect(container.read(projectNavbarIndexProvider), 3);
-
-    // ...the Specimens page is now the visible one...
     expect(find.text('PAGE-Specimens'), findsOneWidget);
 
-    // ...and crucially, no new route was pushed (no page-transition / stacking).
+    // Crucially, no new route was pushed.
     expect(observer.pushCount, pushesAfterInitialRoute);
   });
 
@@ -83,9 +79,8 @@ void main() {
     await tester.tap(find.text('Narrative'));
     await tester.pumpAndSettle();
 
-    // IndexedStack retains all children (offstage), so the Dashboard page is
-    // still mounted even though Narrative is selected — this is what preserves
-    // per-screen state across tab switches.
+    // IndexedStack keeps unselected pages mounted (offstage) — this is what
+    // preserves per-screen state across tab switches.
     expect(
       find.text('PAGE-Dashboard', skipOffstage: false),
       findsOneWidget,

--- a/test/site_view_reconcile_test.dart
+++ b/test/site_view_reconcile_test.dart
@@ -9,6 +9,7 @@ import 'package:nahpu/screens/sites/site_view.dart';
 import 'package:nahpu/services/database/database.dart';
 import 'package:nahpu/services/database/site_queries.dart';
 import 'package:nahpu/services/providers/database.dart';
+import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/providers/sites.dart';
 
@@ -78,9 +79,9 @@ void main() {
 
     final container = await pumpViewer(tester, db);
 
-    // Three sites, sitting on the first page.
+    // Three sites; the first load lands on the last record.
     expect(find.byType(SitePages), findsOneWidget);
-    expect(find.text('Page 1 of 3'), findsAtLeastNWidgets(1));
+    expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
     expect(tester.takeException(), isNull);
 
     // Delete the middle site the way the menu bar does: query + invalidate.
@@ -89,8 +90,8 @@ void main() {
     await tester.pumpAndSettle();
 
     // The counter is reconciled to the shrunk list, not left out of range.
-    expect(find.text('Page 1 of 2'), findsAtLeastNWidgets(1));
-    expect(find.text('Page 1 of 3'), findsNothing);
+    expect(find.text('Page 2 of 2'), findsAtLeastNWidgets(1));
+    expect(find.text('Page 3 of 3'), findsNothing);
     expect(tester.takeException(), isNull);
     expect((await SiteQuery(db).getAllSites(projectUuid)).length, 2);
 
@@ -107,11 +108,7 @@ void main() {
 
     final container = await pumpViewer(tester, db);
 
-    // Navigate to the last page (3 of 3).
-    await tester.fling(find.byType(PageView), const Offset(-600, 0), 2000);
-    await tester.pumpAndSettle();
-    await tester.fling(find.byType(PageView), const Offset(-600, 0), 2000);
-    await tester.pumpAndSettle();
+    // The first load lands on the last page (3 of 3).
     expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
 
     // Delete the record we're sitting on; currentPage (3) now exceeds the new
@@ -160,6 +157,54 @@ void main() {
     // would leave Duplicate/Delete and search permanently disabled.
     final menu = tester.widget<SiteMenu>(find.byType(SiteMenu));
     expect(menu.siteId, onlyId);
+
+    await drainOverlayTimer(tester);
+  });
+
+  testWidgets('first load lands on the last record', (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    await seedSite(db);
+    await seedSite(db);
+    final lastId = await seedSite(db);
+
+    await pumpViewer(tester, db);
+
+    // Matches the old per-tab-push behavior: opening a viewer showed the most
+    // recent record, not the first. Later refreshes preserve the position.
+    expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
+    expect(tester.widget<SiteMenu>(find.byType(SiteMenu)).siteId, lastId);
+    expect(tester.takeException(), isNull);
+
+    await drainOverlayTimer(tester);
+  });
+
+  testWidgets('creating a site lands on the new record', (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    await seedSite(db);
+    await seedSite(db);
+
+    final container = await pumpViewer(tester, db);
+    expect(find.text('Page 2 of 2'), findsAtLeastNWidgets(1));
+
+    // Simulate the menu bar's create flow: insert the record, file the
+    // pending jump under its id, and invalidate the list.
+    final newId = await seedSite(db);
+    container.read(pendingRecordJumpProvider(RecordViewer.site).notifier).state =
+        newId;
+    container.invalidate(siteEntryProvider);
+    await tester.pumpAndSettle();
+
+    // The viewer lands on the new record instead of preserving the page, and
+    // the one-shot request is consumed.
+    expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
+    expect(tester.widget<SiteMenu>(find.byType(SiteMenu)).siteId, newId);
+    expect(
+      container.read(pendingRecordJumpProvider(RecordViewer.site)),
+      isNull,
+    );
+    expect(tester.takeException(), isNull);
 
     await drainOverlayTimer(tester);
   });

--- a/test/site_view_reconcile_test.dart
+++ b/test/site_view_reconcile_test.dart
@@ -13,14 +13,9 @@ import 'package:nahpu/services/providers/page_jump.dart';
 import 'package:nahpu/services/providers/projects.dart';
 import 'package:nahpu/services/providers/sites.dart';
 
-/// Widget-level regression tests for the in-place refresh hardening from issue
-/// #132 (Fix B/C). They drive the real [SiteViewer] against an in-memory
-/// database — no mocked widgets — so they exercise the same `ref.listen` /
-/// `_reconcile` path the running app uses.
-///
-/// Under the pre-fix code these would fail: the empty branch called
-/// `setState` during build (illegal in a test), and after a delete the page
-/// counter went out of range ("Page 1 of 3" against a 2-item list).
+/// Regression tests for the issue #132 in-place refresh: they drive the real
+/// [SiteViewer] against an in-memory database, exercising the same
+/// `ref.listen`/`_reconcile` path as the running app.
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   const pathChannel = MethodChannel('plugins.flutter.io/path_provider');
@@ -79,7 +74,6 @@ void main() {
 
     final container = await pumpViewer(tester, db);
 
-    // Three sites; the first load lands on the last record.
     expect(find.byType(SitePages), findsOneWidget);
     expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
     expect(tester.takeException(), isNull);
@@ -89,7 +83,6 @@ void main() {
     container.invalidate(siteEntryProvider);
     await tester.pumpAndSettle();
 
-    // The counter is reconciled to the shrunk list, not left out of range.
     expect(find.text('Page 2 of 2'), findsAtLeastNWidgets(1));
     expect(find.text('Page 3 of 3'), findsNothing);
     expect(tester.takeException(), isNull);
@@ -108,11 +101,10 @@ void main() {
 
     final container = await pumpViewer(tester, db);
 
-    // The first load lands on the last page (3 of 3).
     expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
 
-    // Delete the record we're sitting on; currentPage (3) now exceeds the new
-    // count (2) and must be clamped instead of rendering "Page 3 of 2".
+    // Delete the record we're sitting on; currentPage must clamp from 3 to 2
+    // instead of rendering "Page 3 of 2".
     await SiteQuery(db).deleteSite(lastId);
     container.invalidate(siteEntryProvider);
     await tester.pumpAndSettle();
@@ -151,10 +143,8 @@ void main() {
 
     await pumpViewer(tester, db);
 
-    // The menu must target the on-screen record without requiring a swipe:
-    // onPageChanged never fires for the initially shown page, and with a
-    // single record there is no other page to swipe to, so a null id here
-    // would leave Duplicate/Delete and search permanently disabled.
+    // onPageChanged never fires for the initially shown page, so a null id
+    // here would leave Duplicate/Delete and search permanently disabled.
     final menu = tester.widget<SiteMenu>(find.byType(SiteMenu));
     expect(menu.siteId, onlyId);
 
@@ -170,10 +160,9 @@ void main() {
 
     await pumpViewer(tester, db);
 
-    // Matches the old per-tab-push behavior: opening a viewer showed the most
-    // recent record, not the first. Later refreshes preserve the position.
-    // Assert the real viewport position, not just the counter text — the
-    // counter reads PageNavigation bookkeeping and can lie about the view.
+    // Matches the old behavior: a viewer opens on the most recent record.
+    // Assert the real viewport, not just the counter text — the counter reads
+    // bookkeeping and can lie about the view.
     expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
     final controller = tester.widget<PageView>(find.byType(PageView)).controller;
     expect(controller?.page, 2.0);
@@ -200,11 +189,9 @@ void main() {
     container.invalidate(siteEntryProvider);
     await tester.pumpAndSettle();
 
-    // The viewer lands on the new record instead of preserving the page, and
-    // the one-shot request is consumed. The viewport itself must move: the
-    // attached PageView keeps its scroll position across a controller swap,
-    // so a counter-only check would pass while the view (and the < > nav
-    // buttons, which navigate relative to the real position) stayed behind.
+    // Lands on the new record and consumes the one-shot request. Check the
+    // real viewport too — a counter-only check can pass while the view stays
+    // behind.
     expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
     final controller = tester.widget<PageView>(find.byType(PageView)).controller;
     expect(controller?.page, 2.0);
@@ -242,10 +229,9 @@ void main() {
     container.invalidate(siteEntryProvider);
     await tester.pumpAndSettle();
 
-    // Regression guard: a jump on the live controller raced the refreshed
-    // list's layout, clamped to the old last page, and corrupted the page
-    // bookkeeping ("5 of 5" flashing, then stuck one page short). The keyed
-    // controller swap must land the real viewport on the new record.
+    // Regression guard: a live-controller jump raced the refreshed list's
+    // layout and stuck the view one page short. The keyed controller swap
+    // must land the real viewport on the new record.
     expect(find.text('Page 5 of 5'), findsAtLeastNWidgets(1));
     final controller =
         tester.widget<PageView>(find.byType(PageView)).controller;

--- a/test/site_view_reconcile_test.dart
+++ b/test/site_view_reconcile_test.dart
@@ -217,4 +217,42 @@ void main() {
 
     await drainOverlayTimer(tester);
   });
+
+  testWidgets('creating from a non-last page lands on the new record',
+      (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    for (var i = 0; i < 4; i++) {
+      await seedSite(db);
+    }
+
+    final container = await pumpViewer(tester, db);
+
+    // First load lands on 4 of 4; swipe back into the middle of the list.
+    await tester.fling(find.byType(PageView), const Offset(600, 0), 2000);
+    await tester.pumpAndSettle();
+    await tester.fling(find.byType(PageView), const Offset(600, 0), 2000);
+    await tester.pumpAndSettle();
+    expect(find.text('Page 2 of 4'), findsAtLeastNWidgets(1));
+
+    final newId = await seedSite(db);
+    container
+        .read(pendingRecordJumpProvider(RecordViewer.site).notifier)
+        .state = newId;
+    container.invalidate(siteEntryProvider);
+    await tester.pumpAndSettle();
+
+    // Regression guard: a jump on the live controller raced the refreshed
+    // list's layout, clamped to the old last page, and corrupted the page
+    // bookkeeping ("5 of 5" flashing, then stuck one page short). The keyed
+    // controller swap must land the real viewport on the new record.
+    expect(find.text('Page 5 of 5'), findsAtLeastNWidgets(1));
+    final controller =
+        tester.widget<PageView>(find.byType(PageView)).controller;
+    expect(controller?.page, 4.0);
+    expect(tester.widget<SiteMenu>(find.byType(SiteMenu)).siteId, newId);
+    expect(tester.takeException(), isNull);
+
+    await drainOverlayTimer(tester);
+  });
 }

--- a/test/site_view_reconcile_test.dart
+++ b/test/site_view_reconcile_test.dart
@@ -172,7 +172,11 @@ void main() {
 
     // Matches the old per-tab-push behavior: opening a viewer showed the most
     // recent record, not the first. Later refreshes preserve the position.
+    // Assert the real viewport position, not just the counter text — the
+    // counter reads PageNavigation bookkeeping and can lie about the view.
     expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
+    final controller = tester.widget<PageView>(find.byType(PageView)).controller;
+    expect(controller?.page, 2.0);
     expect(tester.widget<SiteMenu>(find.byType(SiteMenu)).siteId, lastId);
     expect(tester.takeException(), isNull);
 
@@ -197,8 +201,13 @@ void main() {
     await tester.pumpAndSettle();
 
     // The viewer lands on the new record instead of preserving the page, and
-    // the one-shot request is consumed.
+    // the one-shot request is consumed. The viewport itself must move: the
+    // attached PageView keeps its scroll position across a controller swap,
+    // so a counter-only check would pass while the view (and the < > nav
+    // buttons, which navigate relative to the real position) stayed behind.
     expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
+    final controller = tester.widget<PageView>(find.byType(PageView)).controller;
+    expect(controller?.page, 2.0);
     expect(tester.widget<SiteMenu>(find.byType(SiteMenu)).siteId, newId);
     expect(
       container.read(pendingRecordJumpProvider(RecordViewer.site)),

--- a/test/site_view_reconcile_test.dart
+++ b/test/site_view_reconcile_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:nahpu/screens/sites/components/menu_bar.dart';
 import 'package:nahpu/screens/sites/site_view.dart';
 import 'package:nahpu/services/database/database.dart';
 import 'package:nahpu/services/database/site_queries.dart';
@@ -141,6 +142,24 @@ void main() {
 
     expect(find.byType(EmptySite), findsOneWidget);
     expect(tester.takeException(), isNull);
+
+    await drainOverlayTimer(tester);
+  });
+
+  testWidgets('first load points the menu at the visible record',
+      (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    final onlyId = await seedSite(db);
+
+    await pumpViewer(tester, db);
+
+    // The menu must target the on-screen record without requiring a swipe:
+    // onPageChanged never fires for the initially shown page, and with a
+    // single record there is no other page to swipe to, so a null id here
+    // would leave Duplicate/Delete and search permanently disabled.
+    final menu = tester.widget<SiteMenu>(find.byType(SiteMenu));
+    expect(menu.siteId, onlyId);
 
     await drainOverlayTimer(tester);
   });

--- a/test/site_view_reconcile_test.dart
+++ b/test/site_view_reconcile_test.dart
@@ -1,0 +1,147 @@
+import 'package:drift/drift.dart' show DatabaseConnection, Value;
+import 'package:drift/native.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nahpu/screens/sites/site_view.dart';
+import 'package:nahpu/services/database/database.dart';
+import 'package:nahpu/services/database/site_queries.dart';
+import 'package:nahpu/services/providers/database.dart';
+import 'package:nahpu/services/providers/projects.dart';
+import 'package:nahpu/services/providers/sites.dart';
+
+/// Widget-level regression tests for the in-place refresh hardening from issue
+/// #132 (Fix B/C). They drive the real [SiteViewer] against an in-memory
+/// database — no mocked widgets — so they exercise the same `ref.listen` /
+/// `_reconcile` path the running app uses.
+///
+/// Under the pre-fix code these would fail: the empty branch called
+/// `setState` during build (illegal in a test), and after a delete the page
+/// counter went out of range ("Page 1 of 3" against a 2-item list).
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const pathChannel = MethodChannel('plugins.flutter.io/path_provider');
+  const projectUuid = 'proj-1';
+
+  setUpAll(() {
+    // SiteForm's media/coordinate components touch path_provider.
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(pathChannel, (call) async => '/tmp');
+  });
+
+  Future<ProviderContainer> pumpViewer(WidgetTester tester, Database db) async {
+    final container = ProviderContainer(
+      overrides: [databaseProvider.overrideWithValue(db)],
+    );
+    container.read(projectUuidProvider.notifier).updateProjectUuid(projectUuid);
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: SiteViewer()),
+      ),
+    );
+    await tester.pumpAndSettle();
+    return container;
+  }
+
+  Future<int> seedSite(Database db) {
+    return db.into(db.site).insert(
+          const SiteCompanion(projectUuid: Value(projectUuid)),
+        );
+  }
+
+  // PageViewer schedules a one-shot 5s timer to hide the page-number overlay;
+  // fire it so no timer is pending when the tree is disposed.
+  Future<void> drainOverlayTimer(WidgetTester tester) =>
+      tester.pump(const Duration(seconds: 6));
+
+  testWidgets('empty list renders without a setState-during-build error',
+      (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+
+    await pumpViewer(tester, db);
+
+    expect(find.byType(EmptySite), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('deleting a mid-list site clamps the page counter into range',
+      (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    await seedSite(db);
+    final middleId = await seedSite(db);
+    await seedSite(db);
+
+    final container = await pumpViewer(tester, db);
+
+    // Three sites, sitting on the first page.
+    expect(find.byType(SitePages), findsOneWidget);
+    expect(find.text('Page 1 of 3'), findsAtLeastNWidgets(1));
+    expect(tester.takeException(), isNull);
+
+    // Delete the middle site the way the menu bar does: query + invalidate.
+    await SiteQuery(db).deleteSite(middleId);
+    container.invalidate(siteEntryProvider);
+    await tester.pumpAndSettle();
+
+    // The counter is reconciled to the shrunk list, not left out of range.
+    expect(find.text('Page 1 of 2'), findsAtLeastNWidgets(1));
+    expect(find.text('Page 1 of 3'), findsNothing);
+    expect(tester.takeException(), isNull);
+    expect((await SiteQuery(db).getAllSites(projectUuid)).length, 2);
+
+    await drainOverlayTimer(tester);
+  });
+
+  testWidgets('deleting the last page while viewing it clamps back one page',
+      (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    await seedSite(db);
+    await seedSite(db);
+    final lastId = await seedSite(db);
+
+    final container = await pumpViewer(tester, db);
+
+    // Navigate to the last page (3 of 3).
+    await tester.fling(find.byType(PageView), const Offset(-600, 0), 2000);
+    await tester.pumpAndSettle();
+    await tester.fling(find.byType(PageView), const Offset(-600, 0), 2000);
+    await tester.pumpAndSettle();
+    expect(find.text('Page 3 of 3'), findsAtLeastNWidgets(1));
+
+    // Delete the record we're sitting on; currentPage (3) now exceeds the new
+    // count (2) and must be clamped instead of rendering "Page 3 of 2".
+    await SiteQuery(db).deleteSite(lastId);
+    container.invalidate(siteEntryProvider);
+    await tester.pumpAndSettle();
+
+    expect(find.text('Page 2 of 2'), findsAtLeastNWidgets(1));
+    expect(find.text('Page 3 of 2'), findsNothing);
+    expect(tester.takeException(), isNull);
+
+    await drainOverlayTimer(tester);
+  });
+
+  testWidgets('deleting the last remaining site shows the empty state',
+      (tester) async {
+    final db = Database.forTesting(DatabaseConnection(NativeDatabase.memory()));
+    addTearDown(db.close);
+    final onlyId = await seedSite(db);
+
+    final container = await pumpViewer(tester, db);
+    expect(find.byType(SitePages), findsOneWidget);
+
+    await SiteQuery(db).deleteSite(onlyId);
+    container.invalidate(siteEntryProvider);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(EmptySite), findsOneWidget);
+    expect(tester.takeException(), isNull);
+
+    await drainOverlayTimer(tester);
+  });
+}


### PR DESCRIPTION
### Video Demo

Before | After


https://github.com/user-attachments/assets/6aeaf323-b0b0-4fb6-8e91-41a44081d2fe



### Review Points
Since it involves re-architecting the foundation, it may have introduced regressions.
Strongly recommended to build this branch locally and test it to verify everything works as desired.

<details>
<summary><h3>Architecture Notes (long read, but worth reading 🤞🏼)</h3></summary>

The big picture first: the old architecture leaned on **"throw the whole screen away and rebuild it, and everything resets"** — brute-force recreation — and the correct behaviors fell out as *side effects* of that. The new architecture keeps the screens alive (IndexedStack) and breaks each behavior out into an **explicit mechanism**. Every bug we hit along the way was a behavior we used to get for free as a side effect, surfacing while being reimplemented explicitly.

## 1. Navigation layer

**Before:** every tab tap did a `Navigator.pushReplacement` to a fresh Dashboard/SiteViewer/... route. Each of the five screens carried its own `Scaffold` + its own bottom navbar + its own `FalseWillPop`. Forms, search, and statistics screens also closed via `pushReplacement(Dashboard())` — stacking **yet another fresh Dashboard** — so the route stack kept growing.

**After:** a single `ProjectShell` holds all five screens in an `IndexedStack`; a tab tap only changes `projectNavbarIndexProvider` (an int). No route push means no page-transition animation (the point of this PR), and the navbar and `FalseWillPop` exist exactly once, on the shell. Screens pushed on top return to the **existing** shell via `popToShell` (`popUntil` to `routeName == 'project_shell'`). The stack is always bounded: `[Home, Shell, (0..n transient screens)]`.

## 2. Data refresh

**Before:** screens were re-mounted constantly, so autoDispose providers died and re-fetched naturally. There was no explicit notion of "refresh" — recreation *was* the refresh.

**After:** the five screens stay mounted, so their providers never lose listeners; refresh points must be explicit: a tab tap invalidates that section's providers, CRUD invalidates the entry provider. Each viewer runs `ref.listen → _reconcile` to fix up its page bookkeeping when data changes. One rule learned the hard way: an in-flight refresh emits a loading-with-previous state that still carries the OLD list — `_reconcile` must skip emissions where `isLoading` is true, because `AsyncValue.whenData` happily unwraps the previous value.

## 3. Page-controller lifetime — the most changed part

**Before:** every data build recreated the controller: `PageController(initialPage: pageCounts + 1, keepPage: false)` (`updatePageController`). That one line did four jobs at once:

- the out-of-range `initialPage` got clamped → **always landed on the last (newest) record**, both on open and after a create;
- the clamp correction fired `onPageChanged` → **the selected-record id got set** (enabling the menu/search);
- in exchange: the previous controller **leaked** (never disposed), the position **reset on every refresh**, and the rebuild loop caused the **query storm**.

**After:** in principle one controller per State lifetime. The four jobs were split into explicit mechanisms:

| Side effect we used to get for free | Explicit mechanism now |
|---|---|
| Open viewer → last record | `_loadedOnce` flag — land on the last page only on the State's first data load |
| Create/duplicate → land on the new record | `pendingRecordJumpProvider` — handlers file the **new record's id**; reconcile consumes it only once the id actually appears in the list (immune to emission ordering) |
| Selected id gets set | derived directly in `_reconcile`: null when empty, visible page's id when null/stale, target id when landing |
| Range correction after delete | `clampToCount` (math) + post-frame `clampController` (the actual jump, which now **refuses to jump beyond the laid-out extent**) |

## 4. The final shape of "landing"

Landing is the only place a controller swap still happens. The reason is two fundamental Flutter constraints we ran into:

- **Swapping the controller on an attached PageView re-attaches the EXISTING scroll position** — `initialPage` is ignored and the viewport doesn't move.
- **Jumping the live controller races the refreshed list's layout** — the jump clamps against the stale (pre-refresh) extent and fires a spurious `onPageChanged` that corrupts the bookkeeping

Final design: each viewer's `PageView` is keyed by `ObjectKey(pageNav.pageController)`, and landing calls `openControllerAt`, which swaps in a fresh `PageController(initialPage: index, keepPage: false)`. The key change rebuilds the PageView as a **new element with a brand-new scroll position** that starts exactly on the target page. There is no jump at all, so the extent race and the spurious event are structurally impossible. In a sense this localizes the old architecture's intuition — "recreate and it's clean" — **down to the one widget that is cheap to recreate**: instead of throwing away the whole screen, we throw away only the PageView.

## 5. The create flow, before and after

**Before:** menu create → INSERT → `pushReplacement(SiteViewer())` → new State, new controller (`initialPage = count + 1`) → clamp shows the last page and `onPageChanged` sets the id. (Cost: full screen rebuild, transition flash, all form/scroll state lost, controller leak.)

**After:** menu create → INSERT → file the returned id in `pendingRecordJumpProvider` → `invalidate` → new list emission → `_reconcile` finds and consumes the id → sets the bookkeeping and does the keyed swap, recreating only the PageView, starting on the new record. (The screen, forms, and every other tab keep their state.)

## Trade-off summary

What the new architecture buys: animation-free tab switches, state preserved across tabs, no controller leaks or query storms, a bounded route stack. What it costs: behaviors that used to be implicit are now **explicit state** (`_loadedOnce`, the pending id, the reconcile rules) repeated across four viewers following the same pattern. The safety net for that repetition is the regression tests asserting the real viewport (`controller.page`), not just the counter text — counter-only assertions can lie about the view. Extracting the shared pattern into a mixin or a common widget is a plausible follow-up refactor, but it was kept out of this PR's scope.
</details>

resolves #132 