### PR TITLE
Fix stale search page for #92

### DIFF
--- a/lib/screens/events/components/personnel.dart
+++ b/lib/screens/events/components/personnel.dart
@@ -263,14 +263,23 @@ class EventPersonnelFieldState extends ConsumerState<EventPersonnelField> {
               hintText: 'Enter a name',
             ),
             items: ref.watch(projectPersonnelProvider).when(
-                  data: (value) => value
-                      .map((person) => DropdownMenuItem(
-                            value: person.uuid,
-                            child: CommonDropdownText(
-                              text: person.name ?? '',
-                            ),
-                          ))
-                      .toList(),
+                  data: (value) {
+                    final personnel = value
+                        .fold<Map<String, PersonnelData>>(
+                          {},
+                          (map, person) => map..[person.uuid] = person,
+                        )
+                        .values
+                        .toList();
+                    return personnel
+                        .map((person) => DropdownMenuItem(
+                              value: person.uuid,
+                              child: CommonDropdownText(
+                                text: person.name ?? '',
+                              ),
+                            ))
+                        .toList();
+                  },
                   loading: () => const [],
                   error: (error, stack) => const [],
                 ),
@@ -317,6 +326,10 @@ class PersonnelRoleState extends ConsumerState<PersonnelRole> {
   Widget build(BuildContext context) {
     return ref.watch(userDefinedFieldProvider(collRolePrefKey)).when(
           data: (data) {
+            final roles = {
+              ...data,
+              if (widget.controller.roleCtr != null) widget.controller.roleCtr!,
+            }.toList();
             return DropdownButtonFormField<String>(
               isExpanded: true,
               initialValue: widget.controller.roleCtr,
@@ -324,7 +337,7 @@ class PersonnelRoleState extends ConsumerState<PersonnelRole> {
                 labelText: 'Role',
                 hintText: 'Enter a role',
               ),
-              items: data
+              items: roles
                   .map((role) => DropdownMenuItem(
                         value: role,
                         child: CommonDropdownText(text: role),

--- a/lib/screens/specimens/specimen_view.dart
+++ b/lib/screens/specimens/specimen_view.dart
@@ -239,20 +239,50 @@ class SpecimenPages extends StatelessWidget {
       controller: pageNav.pageController,
       itemCount: specimenEntry.length,
       itemBuilder: (context, index) {
-        CatalogFmt catalogFmt =
-            matchTaxonGroupToCatFmt(specimenEntry[index].taxonGroup);
-        final specimenFormCtr = _updateController(specimenEntry[index]);
-        return PageViewer(
+        return _SpecimenPage(
+          specimen: specimenEntry[index],
           pageNav: pageNav,
           isNavButtonVisible: isNavButtonVisible,
-          child: SpecimenForm(
-            specimenUuid: specimenEntry[index].uuid,
-            specimenCtr: specimenFormCtr,
-            catalogFmt: catalogFmt,
-          ),
         );
       },
       onPageChanged: onPageChanged,
+    );
+  }
+}
+
+class _SpecimenPage extends ConsumerWidget {
+  const _SpecimenPage({
+    required this.specimen,
+    required this.pageNav,
+    required this.isNavButtonVisible,
+  });
+
+  final SpecimenData specimen;
+  final bool isNavButtonVisible;
+  final PageNavigation pageNav;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final currentSpecimen = ref.watch(specimenEntryProvider).maybeWhen(
+          data: (entries) => entries.firstWhere(
+            (entry) => entry.uuid == specimen.uuid,
+            orElse: () => specimen,
+          ),
+          orElse: () => specimen,
+        );
+
+    CatalogFmt catalogFmt = matchTaxonGroupToCatFmt(currentSpecimen.taxonGroup);
+    final specimenFormCtr = _updateController(currentSpecimen);
+
+    return PageViewer(
+      pageNav: pageNav,
+      isNavButtonVisible: isNavButtonVisible,
+      child: SpecimenForm(
+        key: ValueKey('${currentSpecimen.uuid}-${currentSpecimen.speciesID}'),
+        specimenUuid: currentSpecimen.uuid,
+        specimenCtr: specimenFormCtr,
+        catalogFmt: catalogFmt,
+      ),
     );
   }
 

--- a/lib/services/specimen_services.dart
+++ b/lib/services/specimen_services.dart
@@ -273,7 +273,7 @@ class SpecimenServices extends AppServices {
   }
 
   Future<void> updateSpecimen(String uuid, SpecimenCompanion entries) async {
-    _updateSpecimen(uuid, entries);
+    await _updateSpecimen(uuid, entries);
     invalidateSpecimenList();
   }
 


### PR DESCRIPTION
This fixes stale form state when editing specimen records from search results. Previously, edits could be saved to the database, but the search result page could continue rendering an older specimen snapshot when moving between result pages.

Before:

https://github.com/user-attachments/assets/b18a6cfa-0290-43a3-af57-852ef539b35f

After:

https://github.com/user-attachments/assets/4bc00a72-3967-4db9-8ee0-e4ae6c5890d1

After refreshing each specimen page from the latest `specimenEntryProvider` data by UUID, a fragile events dropdown issue is exposed that a saved dropdown value could fail to render if that value was not present in the current dropdown option list, causing Flutter's dropdown assertion error. The fix in lib/screens/events/components/personnel.dart adds the current saved value into the dropdown option list before rendering.

It also fixes window resizing overflow issue:
<img width="754" height="647" alt="Screenshot 2026-06-19 at 7 53 07 AM" src="https://github.com/user-attachments/assets/f43d20c4-dc69-4988-a037-317e72087f60" />


